### PR TITLE
Fixes inconsistency in Rake task section

### DIFF
--- a/ruby/ruby-tips.html.md.erb
+++ b/ruby/ruby-tips.html.md.erb
@@ -101,7 +101,7 @@ The following is an example of the "migrate frequently" method described in the
    ---
     applications:
     - name: my-rails-app
-      command: bundle exec rake cf:on_primary_instance db:migrate && rails s
+      command: bundle exec rake cf:on_first_instance db:migrate && rails s
     ~~~
 
 3. Update the application using `cf push`.


### PR DESCRIPTION
The Rakefile uses `on_first_instance` but the manifest file uses `on_primary_instance`.
