### PR TITLE
clarify that database.yml is only overridden for Rails < 4

### DIFF
--- a/ruby/ruby-service-bindings.html.md
+++ b/ruby/ruby-service-bindings.html.md
@@ -56,12 +56,12 @@ Cloud Foundry as a candidate for `DATABASE_URL`:
 
 Cloud Foundry uses the first candidate found to populate `DATABASE_URL`.
 
-## <a id='rails-applications-have-autoconfigured-database-yml'></a>Rails Applications Have Auto-Configured database.yml ##
+## <a id='older-rails-applications-have-autoconfigured-database-yml'></a>Older Rails Applications Have Auto-Configured database.yml ##
 
-During staging, the Ruby buildpack replaces your `database.yml` with one based 
+On Rails < 4, the Ruby buildpack replaces your `database.yml` with one based 
 on the `DATABASE_URL` variable.
 
-<p class='note'><strong>Note</strong>: The Ruby buildpack ignores the contents 
+<p class='note'><strong>Note</strong>: On Rails < 4, the Ruby buildpack ignores the contents 
   of any <code>database.yml</code> that you provide and overwrites it during 
   staging.</p>
 


### PR DESCRIPTION
...or is it < 4.1? I'm not quite understanding where the code is in [the buildpack](https://github.com/cloudfoundry/ruby-buildpack) that determines whether to [write the `database.yml`](https://github.com/cloudfoundry/ruby-buildpack/blob/v1.5.0/lib/language_pack/ruby.rb#L629-L694) or not, but the file isn't overwritten for me using Rails 4.2.3 on `ruby_buildpack-cached-v1.4.1`. Seems to be the case on v1.5.0 as well:

https://github.com/cloudfoundry/ruby-buildpack/blob/v1.5.0/spec/rails41_spec.rb#L16

Thanks!