### PR TITLE
Added page to buildbacks documentation explaining missing binary depe…

### DIFF
--- a/supported-binary-dependencies.html.md.erb
+++ b/supported-binary-dependencies.html.md.erb
@@ -1,0 +1,16 @@
+---
+title: Supported Binary Dependencies
+---
+
+Each buildpack only supports the stable patches for each dependency listed in the buildpack's `manifest.yml` and also in its github releases page (see [php-buildpack releases page](https://github.com/cloudfoundry/php-buildpack/releases)).
+
+
+If you try to use a binary that is not currently supported, staging your app will fail and you will see the following error message:
+
+```
+       Could not get translated url, exited with: DEPENDENCY_MISSING_IN_MANIFEST: ...
+ !
+ !     exit
+ !
+Staging failed: Buildpack compilation step failed
+```


### PR DESCRIPTION
Hi, we are submitting a pull request to add a page to the Cloud Foundry documentation for buildpacks [here](http://docs.cloudfoundry.org/buildpacks/). We might be missing changes to add a link to this page in the left-side navigation, please let us know. Thank you.