### PR TITLE
25mb rediscloud plan is no longer offered

### DIFF
--- a/java/gsg-ratpack.html.md.erb
+++ b/java/gsg-ratpack.html.md.erb
@@ -121,17 +121,17 @@ service       plans        description
 
 elephantsql   turtle, panda, elephant      PostgreSQL as a Service
 ...
-rediscloud    25mb, 100mb, 1gb, 10gb, 50gb Enterprise-Class Redis for Developers
+rediscloud    30mb, 100mb, 1gb, 10gb, 50gb Enterprise-Class Redis for Developers
 ...
 
 </pre>
 
 Run `cf create-service SERVICE PLAN SERVICE_INSTANCE` to create a service instance for your app. Choose a SERVICE and PLAN from the list, and provide a unique name for the SERVICE_INSTANCE.
 
-<p class="tip"><strong>Sample App Step</strong><br />Run <code>cf create-service rediscloud 25mb baby-redis</code>. This creates a service instance named <code>baby-redis</code> that uses the <code>rediscloud</code> service and the <code>25mb</code> plan, as the example below shows.
+<p class="tip"><strong>Sample App Step</strong><br />Run <code>cf create-service rediscloud 30mb baby-redis</code>. This creates a service instance named <code>baby-redis</code> that uses the <code>rediscloud</code> service and the <code>30mb</code> plan, as the example below shows.
 
 <pre class="terminal">
-$ cf create-service rediscloud 25mb baby-redis
+$ cf create-service rediscloud 30mb baby-redis
 Creating service baby-redis in org Cloud-Apps / space development as clouduser@example.com....
 OK
 </pre>

--- a/ruby/gsg-ruby.html.md.erb
+++ b/ruby/gsg-ruby.html.md.erb
@@ -75,10 +75,10 @@ instance for your app.
 Choose a SERVICE and PLAN from the list, and provide a unique name for the
 SERVICE_INSTANCE.
 
-<p class="tip"><strong>Sample App Step</strong><br />Run <code>cf create-service rediscloud 25mb redis</code>. This creates a service instance named <code>redis</code> that uses the <code>rediscloud</code> service and the <code>25mb</code> plan, as the example below shows.</p>
+<p class="tip"><strong>Sample App Step</strong><br />Run <code>cf create-service rediscloud 30mb redis</code>. This creates a service instance named <code>redis</code> that uses the <code>rediscloud</code> service and the <code>30mb</code> plan, as the example below shows.</p>
 
 <pre class="terminal">
-$ cf create-service rediscloud 25mb redis
+$ cf create-service rediscloud 30mb redis
 Creating service redis in org Cloud-Apps / space development as clouduser@example.com....
 OK
 </pre>


### PR DESCRIPTION
According to `cf marketplace -s rediscloud`, the only plans offered are:

```
100mb          Basic                paid
250mb          Mini                 paid
500mb          Small                paid
1gb            Standard             paid
2-5gb          Medium               paid
5gb            Large                paid
10gb           X-Large              paid
50gb           XX-Large             paid
30mb           Lifetime Free Tier   free
```

The documentation in the getting started guide for both Ruby and Java says
to use the 25mb plan. I imagine that at some point the storage limit was
bumped to 30mb.

A very big thank you to @bridgetkromhout for pointing out where these docs
live!

Fixes docs.