### PR TITLE
extend from AbstractCloudConfig to fix AMQP-576

### DIFF
--- a/java/spring-service-bindings.html.md.erb
+++ b/java/spring-service-bindings.html.md.erb
@@ -400,14 +400,12 @@ To configure a RabbitMQ service in Java configuration, create a
 
 ```
 @Configuration
-public class RabbitConfig {
+public class RabbitConfig extends AbstractCloudConfig {
     @Bean
     public ConnectionFactory rabbitConnectionFactory() {
-        CloudFactory cloudFactory = new CloudFactory();
-        Cloud cloud = cloudFactory.getCloud();
-        AmqpServiceInfo serviceInfo = (AmqpServiceInfo) cloud.getServiceInfo("my-rabbit");
+        AmqpServiceInfo serviceInfo = (AmqpServiceInfo) cloud().getServiceInfo("my-rabbit");
     String serviceID = serviceInfo.getID();
-    return cloud.getServiceConnector(serviceID, ConnectionFactory.class, null);
+    return cloud().getServiceConnector(serviceID, ConnectionFactory.class, null);
     }
 
     @Bean


### PR DESCRIPTION
creating your own `CloudFactory` does not work in all my tests, redefining the bean only works when the configuration class is extending `AbstractCloudConfig` to have access to `cloud()`.

for more details see https://jira.spring.io/browse/AMQP-576