### PR TITLE
Adding documentation about deploying applications and standardizing format

### DIFF
--- a/binary/index.html.md.erb
+++ b/binary/index.html.md.erb
@@ -6,9 +6,7 @@ title: Binary Buildpack
 
 Use the binary buildpack for running arbitrary binary web servers.
 
-For more information, see the [buildpack documentation](../index.html).
-
-## Usage ##
+## <a id='pushing_apps'></a> Pushing Apps ##
 
 Unlike most other Cloud Foundry buildpacks, you must specify the binary
 buildpack in order to use it in staging your binary file.
@@ -36,8 +34,7 @@ specifies a `web` task:
    	$ cf push my_app -c './app' -b binary-buildpack
    	```
 
-## Compiling your Binary ##
-
+## <a id='compiling'></a> Compiling your Binary ##
 Cloud Foundry expects your binary to bind to the port specified by the `PORT`
 environment variable.
 
@@ -88,3 +85,13 @@ $ cf push my_app -s (cflinuxfs2|lucid64)
 ```
 
 To run docker on Mac OS X, we recommend [boot2docker](http://boot2docker.io/).
+
+## <a id='help_support'></a>Help and Support ##
+
+Join the #buildpacks channel in our [Slack community] (http://slack.cloudfoundry.org/) if you need any further assistance.
+
+For more information about using and extending the Ruby buildpack in Cloud Foundry, see
+the [ruby-buildpack GitHub repo](https://github.com/cloudfoundry/ruby-buildpack).
+
+You can find current information about this buildpack on the Ruby buildpack
+[release page](https://github.com/cloudfoundry/ruby-buildpack/releases) in GitHub.

--- a/go/index.html.md.erb
+++ b/go/index.html.md.erb
@@ -149,9 +149,6 @@ to, e.g., specify paths for vendored dependencies. E.g., to build
 `CGO_CFLAGS` with the value `-I/app/code/vendor/include/postgresql` and include
 the relevant Postgres header files in `vendor/include/postgresql/` in your app.
 
-## <a id='disconnected'></a> Disconnected environments ##
-To use this buildpack on Cloud Foundry, where the Cloud Foundry instance limits some or all internet activity, please read the [Disconnected Environments documentation](https://github.com/cf-buildpacks/buildpack-packager/blob/master/doc/disconnected_environments.md).
-
 ## <a id='proxy_support'></a> Proxy Support ##
 
 If you need to use a proxy to download dependencies during staging, you can set

--- a/node/index.html.md.erb
+++ b/node/index.html.md.erb
@@ -5,25 +5,89 @@ owner: Buildpacks
 
 <strong><%= modified_date %></strong>
 
-Use the Node.js buildpack with Node or JavaScript applications.
+## <a id='pushing_apps'></a> Pushing Apps ##
 
-See the following topics:
+This buildpack will be automatically used if there is a `package.json` file in the root directory of your project.
+
+If your Cloud Foundry deployment does not have the Node.js Buildpack installed, or the installed version is out of date, you can use the latest version with the command:
+```bash
+cf push my_app -b https://github.com/cloudfoundry/buildpack-nodejs.git
+```
+
+For more detailed information on deploying Node.js applications see the following topics:
 
 * [Tips for Node.js Developers](./node-tips.html)
-* [Environment Variables Defined by the Node Buildpack](./node-environment.html)
-* [Configure Service Connections for Node](node-service-bindings.html)
+* [Environment Variables Defined by the Node.js Buildpack](./node-environment.html)
+* [Configure Service Connections for Node.js](node-service-bindings.html)
 
-The source for the buildpack is [here](https://github.com/cloudfoundry/heroku-buildpack-nodejs).
 
-## Buildpack Logging and Application Logging ##
+## <a id='runtime'></a>Specify a Node.js Version##
 
-The buildpack only runs during the staging process, and therefore only logs
-what is important to staging, such as what is being downloaded, what the
-configuration is, and work that the buildpack does on your application.
+Set engines.node in package.json to the semver range
+(or specific version) of node you'd like to use. For example:
 
-Once staging is done, the buildpack stops logging.
-Application logging is a separate concern.
+```json
+"engines": {
+  "node": "4.4.x"
+}
+```
 
-Your application must write to STDOUT or STDERR for its logs to be included in the
-Loggregator stream.
-See [Application Logging in Cloud Foundry](../../devguide/deploy-apps/streaming-logs.html).
+or
+
+```json
+"engines": {
+  "node": "4.4.3"
+}
+```
+
+If you try to use a version that is not currently supported, staging your app will fail and you will see the following error message:
+
+```
+       Could not get translated url, exited with: DEPENDENCY_MISSING_IN_MANIFEST: ...
+ !
+ !     exit
+ !
+Staging failed: Buildpack compilation step failed
+```
+
+## <a id='vendoring'></a>Vendoring app dependencies ##
+
+As stated in the [Disconnected Environments documentation](https://github.com/cf-buildpacks/buildpack-packager/blob/master/doc/disconnected_environments.md), your application must 'vendor' it's dependencies.
+
+For the Node.js buildpack, use ```npm```:
+
+```shell
+cd <your app dir>
+npm install # vendors into /node_modules
+```
+
+```cf push``` uploads your vendored dependencies.
+
+## <a id='openssl'></a>OpenSSL support ##
+
+Since November 2015, the [nodejs-buildpack](https://github.com/cloudfoundry/nodejs-buildpack)
+has been packaging binaries of Node.js with OpenSSL that are statically linked. With
+[community approval](https://github.com/cloudfoundry/nodejs-buildpack/issues/32), it was
+decided to support Node.js 4.x and greater, which relied on the Node.js release cycle
+to provide OpenSSL updates.
+
+The buildpack's team [binary-builder](https://github.com/cloudfoundry/binary-builder) was
+updated to [enable the static openssl compilation](https://github.com/cloudfoundry/binary-builder/commit/834759affa4d7e42294a54b49bac6f1cf81b798a).
+All versions of Node.js compiled since have been statically linked with OpenSSL, which
+include versions of Node.js greater than and equal to *0.12.10* and *0.10.42*.
+
+## <a id='proxy_support'></a> Proxy Support ##
+
+If you need to use a proxy to download dependencies during staging, you can set
+the `http_proxy` and/or `https_proxy` environment variables. For more information, see
+the [Proxy Usage Docs](http://docs.cloudfoundry.org/buildpacks/proxy-usage.html).
+
+## <a id='help_support'></a>Help and Support ##
+
+Join the #buildpacks channel in our [Slack community] (http://slack.cloudfoundry.org/) if you need any further assistance.
+
+For more information about using and extending the Node.js buildpack in Cloud Foundry, see
+the [nodejs-buildpack GitHub repo](https://github.com/cloudfoundry/nodejs-buildpack).
+
+You can find current information about this buildpack on the Node.js buildpack
+[release page](https://github.com/cloudfoundry/nodejs-buildpack/releases) in GitHub.

--- a/php/index.html.md.erb
+++ b/php/index.html.md.erb
@@ -7,6 +7,80 @@ owner: Buildpacks
 
 Use the PHP buildpack with PHP or HHVM runtimes.
 
+## <a id='pushing_apps'></a> Pushing Apps ##
+### <a id='quick_start'></a> 30 Second Tutorial ###
+
+Getting started with this buildpack is easy.  With the [`cf` command line utility](https://github.com/cloudfoundry/cli) installed, open a shell, change directories to the root of your PHP files and push your application using the argument `-b https://github.com/cloudfoundry/php-buildpack.git`.
+
+Example:
+
+```bash
+mkdir my-php-app
+cd my-php-app
+cat << EOF > index.php
+<?php
+  phpinfo();
+?>
+EOF
+cf push -m 128M -b https://github.com/cloudfoundry/php-buildpack.git my-php-app
+```
+
+Please note that you should change *my-php-app* to some unique name on your target Cloud Foundry instance, otherwise you'll get a hostname conflict error and the push will fail.
+
+The example above will create and push a test application, *my-php-app*, to Cloud Foundry.  The `-b` argument instructs CF to use this buildpack.  The remainder of the options and arguments are not specific to the buildpack, for questions on those consult the output of `cf help push`.
+
+Here's a breakdown of what happens when you run the example above.
+
+  - On your PC:
+    - It will create a new directory and one PHP file, which just invokes `phpinfo()`
+    - Run `cf` to push your application.  This will create a new application with a memory limit of 128M (more than enough here) and upload our test file.
+  - Within Cloud Foundry:
+    - The buildpack is executed.
+    - Application files are copied to the `htdocs` folder.
+    - Apache HTTPD & PHP are downloaded, configured with the buildpack defaults and run.
+    - Your application is accessible at the URL `http://my-php-app.example.com` (Replacing `example.com` with the domain of your public CF provider or private instance).
+
+### <a id='more_info'></a> More information about deploying ###
+While the *30 Second Tutorial* shows how quick and easy it is to get started using the buildpack, it skips over quite a bit of what you can do to adjust, configure and extend the buildpack.  The following sections and links provide a more in-depth look at the buildpack.
+
+### <a id='supported_software'></a> Supported Software ###
+The [release notes page](https://github.com/cloudfoundry/php-buildpack/releases) has a list of currently supported modules and packages.
+
+* **PHP Runtimes**
+  * php-cli
+  * php-cgi
+  * php-fpm
+* **Third-Party Modules**
+  * New Relic, in connected environments only.
+
+
+### <a id='features'></a> Features ###
+
+Here are some special features of the buildpack.
+
+  - Supports running commands or migration scripts prior to application startup.
+  - Supports an extension mechanism that allows the buildpack to provide additional functionality.
+  - Allows for application developers to provide custom extensions.
+  - Easy troubleshooting with the `BP_DEBUG` environment variable.
+  - Download location is configurable, allowing users to host binaries on the same network (i.e. run without an Internet connection)
+  - Smart session storage, defaults to file w/sticky sessions but can also use redis for storage.
+
+### <a id='examples'></a> Examples ###
+
+Here are some example applications that can be used with this buildpack.
+
+  - [php-info]  This app has a basic index page and shows the output of `phpinfo()`.
+  - [PHPMyAdmin]  A deployment of PHPMyAdmin that uses bound MySQL services.
+  - [PHPPgAdmin] A deployment of PHPPgAdmin that uses bound PostgreSQL services.
+  - [Wordpress]  A deployment of WordPress that uses bound MySQL service.
+  - [Drupal] A deployment of Drupal that uses bound MySQL service.
+  - [CodeIgniter]  CodeIgniter tutorial application running on CF.
+  - [Stand Alone]  An example which runs a standalone PHP script.
+  - [pgbouncer]  An example which runs the PgBouncer process in the container to pool database connections.
+  - [phalcon]  An example which runs a Phalcon based application.
+  - [composer] An example which uses Composer.
+
+### <a id='examples'></a> Advanced Topics ###
 See the following topics:
 
 * [Composer](./gsg-php-composer.html)
@@ -17,15 +91,46 @@ See the following topics:
 
 The source for the buildpack is [here](https://github.com/cloudfoundry/php-buildpack).
 
-## Buildpack Logging and Application Logging ##
+## <a id='proxy_support'></a> Proxy Support ##
 
-The buildpack only runs during the staging process, and therefore only logs
-what is important to staging, such as what is being downloaded, what the
-configuration is, and work that the buildpack does on your application.
+If you need to use a proxy to download dependencies during staging, you can set
+the `http_proxy` and/or `https_proxy` environment variables. For more information, see
+the [Proxy Usage Docs](http://docs.cloudfoundry.org/buildpacks/proxy-usage.html).
 
-Once staging is done, the buildpack stops logging.
-Application logging is a separate concern.
+## <a id='help_support'></a>Help and Support ##
 
-Your application must write to STDOUT or STDERR for its logs to be included in the
-Loggregator stream.
-See [Application Logging in Cloud Foundry](../../devguide/deploy-apps/streaming-logs.html).
+Join the #buildpacks channel in our [Slack community] (http://slack.cloudfoundry.org/) if you need any further assistance.
+
+For more information about using and extending the PHP buildpack in Cloud Foundry, see
+the [php-buildpack GitHub repo](https://github.com/cloudfoundry/php-buildpack).
+
+You can find current information about this buildpack on the PHP buildpack
+[release page](https://github.com/cloudfoundry/php-buildpack/releases) in GitHub.
+
+## License
+
+The Cloud Foundry PHP Buildpack is released under version 2.0 of the [Apache License].
+
+[Configuration Options]:https://github.com/cloudfoundry/php-buildpack/blob/master/docs/config.md
+[Development]:https://github.com/cloudfoundry/php-buildpack/blob/master/docs/development.md
+[Troubleshooting]:https://github.com/cloudfoundry/php-buildpack/blob/master/docs/troubleshooting.md
+[Usage]:https://github.com/cloudfoundry/php-buildpack/blob/master/docs/usage.md
+[Binaries]:https://github.com/cloudfoundry/php-buildpack/blob/master/docs/binaries.md
+[php-info]:https://github.com/dmikusa-pivotal/cf-ex-php-info
+[PHPMyAdmin]:https://github.com/dmikusa-pivotal/cf-ex-phpmyadmin
+[PHPPgAdmin]:https://github.com/dmikusa-pivotal/cf-ex-phppgadmin
+[Wordpress]:https://github.com/dmikusa-pivotal/cf-ex-worpress
+[Drupal]:https://github.com/dmikusa-pivotal/cf-ex-drupal
+[CodeIgniter]:https://github.com/dmikusa-pivotal/cf-ex-code-igniter
+[Stand Alone]:https://github.com/dmikusa-pivotal/cf-ex-stand-alone
+[pgbouncer]:https://github.com/dmikusa-pivotal/cf-ex-pgbouncer
+[Apache License]:http://www.apache.org/licenses/LICENSE-2.0
+[vcap-dev]:https://groups.google.com/a/cloudfoundry.org/forum/#!forum/vcap-dev
+[support forums]:http://support.run.pivotal.io/home
+[Composer support]:https://github.com/cloudfoundry/php-buildpack/blob/master/docs/composer.md
+["offline" mode]:https://github.com/cloudfoundry/php-buildpack/blob/master/docs/binaries.md#bundling-binaries-with-the-build-pack
+[phalcon]:https://github.com/dmikusa-pivotal/cf-ex-phalcon
+[Phalcon]:http://phalconphp.com/en/
+[composer]:https://github.com/dmikusa-pivotal/cf-ex-composer
+[Proxy Support]:http://docs.cloudfoundry.org/buildpacks/proxy-usage.html
+

--- a/python/index.html.md.erb
+++ b/python/index.html.md.erb
@@ -5,15 +5,62 @@ owner: Buildpacks
 
 <strong><%= modified_date %></strong>
 
-## <a id='buildpack'></a>About the Python Buildpack ##
+## <a id='pushing_apps'></a> Pushing Apps ##
 
-For information about using and extending the Python buildpack in Cloud Foundry,
-see the [python-buildpack Github repo](https://github.com/cloudfoundry/python-buildpack).
+This buildpack will be automatically used if there is a `requirements.txt` or `setup.py` file in the root directory of your project.
+
+If your Cloud Foundry deployment does not have the Python Buildpack installed, or the installed version is out of date, you can use the latest version with the command:
+```bash
+cf push my_app -b https://github.com/cloudfoundry/buildpack-python.git
+```
+
+### <a id='runtime'></a>Specify a Python Runtime ###
+
+Specific versions of the Python runtime can be specified with a `runtime.txt` file:
+
+    $ cat runtime.txt
+    python-3.5.1
+
+The buildpack only supports the stable Python versions, which are listed in [manifest.yml](manifest.yml) and [releases page](https://github.com/cloudfoundry/python-buildpack/releases).
+
+If you try to use a binary that is not currently supported, staging your app will fail and you will see the following error message:
+
+```
+       Could not get translated url, exited with: DEPENDENCY_MISSING_IN_MANIFEST: ...
+ !
+ !     exit
+ !
+Staging failed: Buildpack compilation step failed
+```
+
+### <a id='vendoring'></a>Vendoring app dependencies ###
+
+As stated in the [Disconnected Environments documentation](https://github.com/cf-buildpacks/buildpack-packager/blob/master/doc/disconnected_environments.md), your application must 'vendor' it's dependencies.
+
+For the Python buildpack, use ```pip```:
+
+```shell
+cd <your app dir>
+mkdir -p vendor
+
+# vendors all the pip *.tar.gz into vendor/
+pip install --download vendor -r requirements.txt
+```
+
+```cf push``` uploads your vendored dependencies. The buildpack will install them directly from the `vendor/`.
+
+## <a id='proxy_support'></a> Proxy Support ##
+
+If you need to use a proxy to download dependencies during staging, you can set
+the `http_proxy` and/or `https_proxy` environment variables. For more information, see
+the [Proxy Usage Docs](http://docs.cloudfoundry.org/buildpacks/proxy-usage.html).
+
+## <a id='help_support'></a>Help and Support ##
+
+Join the #buildpacks channel in our [Slack community] (http://slack.cloudfoundry.org/) if you need any further assistance.
+
+For more information about using and extending the Python buildpack in Cloud Foundry, see
+the [python-buildpack GitHub repo](https://github.com/cloudfoundry/python-buildpack).
 
 You can find current information about this buildpack on the Python buildpack
-[release page](https://github.com/cloudfoundry/python-buildpack/releases) in
-GitHub.
-
-This buildpack uses a default Python version of `2.7.10`.
-To change the default version, specify the version key in your `runtime.txt`
-file.
+[release page](https://github.com/cloudfoundry/python-buildpack/releases) in GitHub.

--- a/ruby/index.html.md.erb
+++ b/ruby/index.html.md.erb
@@ -5,9 +5,17 @@ owner: Buildpacks
 
 <strong><%= modified_date %></strong>
 
-Use the Ruby buildpack with Ruby, Rack, Rails or Sinatra applications.
+## <a id='pushing_apps'></a> Pushing Apps ##
 
-See the following topics:
+This buildpack will be used if your app has a `Gemfile` and `Gemfile.lock` in the root directory. It will then use Bundler to install your dependencies.
+
+If your Cloud Foundry deployment does not have the Ruby Buildpack installed, or the installed version is out of date, you can use the latest version with the command:
+
+```bash
+cf push my_app -b https://github.com/cloudfoundry/ruby-buildpack.git
+```
+
+For more detailed information on deploying Ruby applications see the following topics:
 
 * [Getting Started Deploying Ruby Apps](./gsg-ruby.html)
 * [Getting Started Deploying Ruby on Rails Apps](./gsg-ror.html)
@@ -18,11 +26,66 @@ See the following topics:
 * [Environment Variables Defined by the Ruby Buildpack](./ruby-environment.html)
 * [Configure Service Connections for Ruby](./ruby-service-bindings.html)
 
+## <a id='runtime'></a>Specify a Ruby Runtime ##
 
-The source for the buildpack is [here](https://github.com/cloudfoundry/cf-buildpack-ruby).
+Specific versions of the Ruby runtime can be specified in the `Gemfile`:
 
-## Buildpack Logging and Application Logging ##
+### <a id='mri_runtime'></a>MRI ###
 
+For MRI you can specify the version of ruby by doing the following:
+
+``` ruby
+ruby '2.2.3'
+```
+
+### <a id='jruby_runtime'></a>JRuby ###
+For JRuby you can specify the version of ruby by doing the following:
+
+JRuby version `1.7.x` supports either `1.9` mode, e.g.:
+
+``` ruby
+ruby '1.9.3', :engine => 'jruby', :engine_version => '1.7.25'
+```
+
+or `2.0` mode, e.g.:
+
+``` ruby
+ruby '2.0.0', :engine => 'jruby', :engine_version => '1.7.25'
+```
+
+For Jruby version `>= 9.0`:
+
+``` ruby
+ruby '2.2.3', :engine => 'jruby', :engine_version => '9.0.5.0'
+```
+
+The buildpack only supports the stable Ruby versions, which are listed in [manifest.yml](manifest.yml) and [releases page](https://github.com/cloudfoundry/ruby-buildpack/releases).
+
+If you try to use a binary that is not currently supported, staging your app will fail and you will see the following error message:
+
+```
+       Could not get translated url, exited with: DEPENDENCY_MISSING_IN_MANIFEST: ...
+ !
+ !     exit
+ !
+Staging failed: Buildpack compilation step failed
+```
+
+## <a id='vendoring'></a>Vendoring app dependencies ##
+
+As stated in the [Disconnected Environments documentation](https://github.com/cf-buildpacks/buildpack-packager/blob/master/doc/disconnected_environments.md), your application must 'vendor' its dependencies.
+
+For the Ruby buildpack, use bundler:
+
+```shell
+cd <your app dir>
+bundle package --all
+```
+
+```cf push``` uploads your vendored dependencies. The buildpack will compile any dependencies requiring compilation while staging your application.
+
+
+## <a id='logging'></a>Buildpack Logging and Application Logging ##
 The buildpack only runs during the staging process, and only logs
 what is important to staging, such as what is being downloaded, what the
 configuration is, and work that the buildpack does on your application.
@@ -45,3 +108,19 @@ You must add the `rails_12factor` gem to your `Gemfile` to quiet the warning mes
 For more information about the `rails_log_stdout` plugin, refer to the [Github README](https://github.com/ddollar/rails_log_stdout).
 
 For more information about the `rails_12factor` gem, refer to the [Github README](https://github.com/heroku/rails_12factor).
+
+## <a id='proxy_support'></a> Proxy Support ##
+
+If you need to use a proxy to download dependencies during staging, you can set
+the `http_proxy` and/or `https_proxy` environment variables. For more information, see
+the [Proxy Usage Docs](http://docs.cloudfoundry.org/buildpacks/proxy-usage.html).
+
+## <a id='help_support'></a>Help and Support ##
+
+Join the #buildpacks channel in our [Slack community] (http://slack.cloudfoundry.org/) if you need any further assistance.
+
+For more information about using and extending the Ruby buildpack in Cloud Foundry, see
+the [ruby-buildpack GitHub repo](https://github.com/cloudfoundry/ruby-buildpack).
+
+You can find current information about this buildpack on the Ruby buildpack
+[release page](https://github.com/cloudfoundry/ruby-buildpack/releases) in GitHub.

--- a/staticfile/index.html.md.erb
+++ b/staticfile/index.html.md.erb
@@ -5,22 +5,28 @@ owner: Buildpacks
 
 <strong><%= modified_date %></strong>
 
-Use the Staticfile buildpack with front-end only web apps or demos.
+## <a id='pushing_apps'></a> Pushing Apps ##
 
-You only need to create a `Staticfile` file for Cloud Foundry to detect this buildpack:
+This buildpack will be used if your directory has a `Staticfile` file in the root directory.
 
+For example:
+
+```bash
+touch Staticfile
+cf push -m 64M
 ```
-$ touch Staticfile
-$ cf push my-site -m 64M
+
+If your Cloud Foundry deployment does not have the Staticfile Buildpack installed, or the installed version is out of date, you can use the latest version with the command:
+
+```bash
+cf push my_app -b https://github.com/cloudfoundry/staticfile-buildpack.git -m 64M
 ```
 
 Why `-m 64M`? Your static assets will be served by [Nginx](http://nginx.com/) and it only requires 20M \[[reference](http://wiki.nginx.org/WhyUseIt)]. The `-m 64M` reduces the RAM allocation from the default 1G allocated to Cloud Foundry containers. In the future there may be a way for a buildpack to indicate its default RAM requirements; but not as of writing.
 
-Configuration
-=============
+## <a id='configuration'></a> Configuration ##
 
-### Alternate root folder
-
+### <a id='root_folder'></a> Alternate root folder ###
 By default, the buildpack will serve `index.html` and all other assets from the root folder of your project.
 
 In many cases, you may have an alternate folder where your HTML/CSS/JavaScript files are to be served from, such as `dist/` or `public/`.
@@ -31,7 +37,7 @@ To configure the buildpack add the following line to your `Staticfile`:
 root: dist
 ```
 
-### Basic authentication
+### <a id='authentication'></a> Basic authentication ###
 
 Protect your website with a user/password configured via environment variables.
 
@@ -49,7 +55,7 @@ bob:$apr1$DuUQEQp8$ZccZCHQElNSjrg.erwSFC0
 
 Push your application to apply changes to basic auth. Remove the file and push to disable basic auth.
 
-### Directory Index
+### <a id='directory_index'></a> Directory Index ###
 
 If your site doesn't have a nice `index.html`, you can configure `Staticfile` to display a Directory Index of other files; rather than show a relatively unhelpful 404 error.
 
@@ -61,7 +67,7 @@ Add a line to your `Staticfile` that begins with `directory:`
 directory: visible
 ```
 
-### Server Side Includes (SSI)
+### <a id='server_side_includes'></a> Server Side Includes (SSI) ###
 
 Add the following line to your `Staticfile` to enable support for [SSI](https://en.wikipedia.org/wiki/Server_Side_Includes):
 
@@ -69,9 +75,9 @@ Add the following line to your `Staticfile` to enable support for [SSI](https://
 ssi: enabled
 ```
 
-### GZip Static
+### <a id='gzip'></a> GZip Static ###
 
-The [`gzip_static`](http://nginx.org/en/docs/http/ngx_http_gzip_static_module.html) and [`gunzip`](http://nginx.org/en/docs/http/ngx_http_gunzip_module.html) modules are set to `on` by default. 
+The [`gzip_static`](http://nginx.org/en/docs/http/ngx_http_gzip_static_module.html) and [`gunzip`](http://nginx.org/en/docs/http/ngx_http_gunzip_module.html) modules are set to `on` by default.
 Together, these modules enable Nginx to properly serve compressed files to clients. They also decompress files for clients that do not support compressed content or responses.
 
 If you want to disable these modules, specify the following in your custom `nginx.conf`:
@@ -81,13 +87,25 @@ gunzip off;
 gzip_static off;
 ```
 
-### Advanced Nginx configuration
+### <a id='gzip'></a> GZip Static ###
 
 You can customize the Nginx configuration further, by adding `nginx.conf` and/or `mime.types` to your root folder.
 
 If the buildpack detects either of these files, they will be used in place of the built-in versions.
 
-For information about using and extending the Staticfile buildpack in Cloud Foundry, see the [staticfile-buildpack GitHub repo](https://github.com/cloudfoundry/staticfile-buildpack).
+
+## <a id='proxy_support'></a> Proxy Support ##
+
+If you need to use a proxy to download dependencies during staging, you can set
+the `http_proxy` and/or `https_proxy` environment variables. For more information, see
+the [Proxy Usage Docs](http://docs.cloudfoundry.org/buildpacks/proxy-usage.html).
+
+## <a id='help_support'></a>Help and Support ##
+
+Join the #buildpacks channel in our [Slack community] (http://slack.cloudfoundry.org/) if you need any further assistance.
+
+For more information about using and extending the Staticfile buildpack in Cloud Foundry, see
+the [staticfile-buildpack GitHub repo](https://github.com/cloudfoundry/staticfile-buildpack).
 
 You can find current information about this buildpack on the Staticfile
 buildpack [release page](https://github.com/cloudfoundry/staticfile-buildpack/releases) in GitHub.


### PR DESCRIPTION
Move documentation about deploying applications from buildpacks README to cf docs

[#118094267]

Signed-off-by: John Shahid <jvshahid@gmail.com>