### PR TITLE
Migrated documentation on sessions and buildpack logs from

### DIFF
--- a/php/gsg-php-sessions.html.md.erb
+++ b/php/gsg-php-sessions.html.md.erb
@@ -1,0 +1,45 @@
+---
+title: Sessions
+owner: Buildpacks
+---
+
+<strong><%= modified_date %></strong>
+
+## <a id='using_session'></a> Usage##
+
+When your application has one instance, it's mostly safe to use the default session storage, which is the local file system.  You would only see problems if your single instance crashes as the local file system would go away and you'd lose your sessions.  For many applications, this will work just fine but please consider how this will impact your application.
+
+If you have multiple application instances or you need a more robust solution for your application, then you'll want to use Redis or Memcached as a backing store for your session data.  The build pack supports both and when one is bound to your application it will detected it and automatically configure PHP to use it for session storage.
+
+By default, there's no configuration necessary.  Simple create a Redis or Memcached service, make sure the service name contains `redis-sessions` or `memcached-sessions` and then bind the service to the application.
+
+Ex:
+
+```
+cf create-service redis some-plan app-redis-sessions
+cf bind-service app app-redis-sessions
+cf restage app
+```
+
+If you want to use a specific service instance or change the search key, you can do that by setting either `REDIS_SESSION_STORE_SERVICE_NAME` or `MEMCACHED_SESSION_STORE_SERVICE_NAME` in `.bp-config/options.json` to the new search key.  The session configuration extension will then search the bound services by name for the new session key.
+
+## <a id='using_session'></a> Configuration Changes##
+
+When detected, the following changes will be made.
+
+### <a id='redis'></a> Redis###
+
+  - the `redis` PHP extension will be installed, which provides the session save handler
+  - `session.name` will be set to `PHPSESSIONID` this disables sticky sessions
+  - `session.save_handler` is configured to `redis`
+  - `session.save_path` is configured based on the bound credentials (i.e. `tcp://host:port?auth=pass`)
+
+### <a id='memcached'></a> Memcached###
+
+ - the `memcached` PHP extension will be installed, which provides the session save handler
+ - `session.name` will be set to `PHPSESSIONID` this disables sticky sessions
+ - `session.save_handler` is configured to `memcached`
+ - `session.save_path` is configured based on the bound credentials (i.e. `PERSISTENT=app_sessions host:port`)
+ - `memcached.sess_binary` is set to `On`
+ - `memcached.use_sasl` is set to `On`, which enables authentication
+ - `memcached.sess_sasl_username` and `memcached.sess_sasl_password` are set with the service credentials.

--- a/php/gsg-php-usage.html.md.erb
+++ b/php/gsg-php-usage.html.md.erb
@@ -142,10 +142,19 @@ There are a couple of easy ways to debug the buildpack:
 
   0. Check the output from the buildpack. It writes some basic information to stdout, like the files that are being downloaded. It writes information should something fail, specifically, stack traces.
 
-  0. Check the logs from the buildpack. The buildpack writes logs to disk. Retrieve them with the `cf files` command, as the following example shows:
+  0. Check the logs from the buildpack. The buildpack writes logs to disk. Retrieve them with the command, as the following example shows:
 
-    ```
+    DEA release
+
+    ```bash
     $ cf files APP app/.bp/logs/bp.log
+    ```
+
+    Diego release
+
+    ```bash
+    $ cf ssh APP
+    $ cat app/.bp/logs/bp.log
     ```
 
   This log is more detailed than the stdout output, however it is still terse.

--- a/php/index.html.md.erb
+++ b/php/index.html.md.erb
@@ -84,6 +84,7 @@ Here are some example applications that can be used with this buildpack.
 See the following topics:
 
 * <a href="./gsg-php-composer.html" class="subnav">Composer</a>
+* <a href="./gsg-php-sessions.html" class="subnav">Sessions</a>
 * <a href="./gsg-php-newrelic.html" class="subnav">New Relic</a>
 * <a href="./gsg-php-config.html" class="subnav">Configuration</a>
 * <a href="./gsg-php-usage.html" class="subnav">Deploying and Developing PHP Apps</a>
@@ -91,19 +92,6 @@ See the following topics:
 
 You can find the source for the buildpack on GitHub:
 [https://github.com/cloudfoundry/php-buildpack](https://github.com/cloudfoundry/php-buildpack)
-
-## <a id='proxy_support'></a> Proxy Support ##
-
-If you need to use a proxy to download dependencies during staging, you can set
-the `http_proxy` and/or `https_proxy` environment variables. For more information, see
-the [Proxy Usage Docs](http://docs.cloudfoundry.org/buildpacks/proxy-usage.html).
-
-## <a id='help_support'></a>Help and Support ##
-
-Join the #buildpacks channel in our [Slack community] (http://slack.cloudfoundry.org/) if you need any further assistance.
-
-For more information about using and extending the PHP buildpack in Cloud Foundry, see
-the [php-buildpack GitHub repo](https://github.com/cloudfoundry/php-buildpack).
 
 ## <a id='proxy_support'></a> Proxy Support ##
 

--- a/toc.html.md.erb
+++ b/toc.html.md.erb
@@ -93,16 +93,17 @@ ___
 
 * [PHP Buildpack](./php/index.html)
 
-* [Tips for PHP Developers](./php/gsg-php-tips.html)
-
 * [Deploying and Developing PHP Apps](./php/gsg-php-usage.html)
-
-* [Composer](./php/gsg-php-composer.html)
-
-* [New Relic](./php/gsg-php-newrelic.html)
 
 * [PHP Buildpack Configuration](./php/gsg-php-config.html)
 
+* [Composer](./php/gsg-php-composer.html)
+
+* [Sessions](./php/gsg-php-sessions.html)
+
+* [New Relic](./php/gsg-php-newrelic.html)
+
+* [Tips for PHP Developers](./php/gsg-php-tips.html)
 ___
 
 ## Python ##


### PR DESCRIPTION
Add a `session` subsection to the php docs. The new section explains how to use `memcached` or `redis` as a session storage with php

[#118608021]

Signed-off-by: John Shahid <jvshahid@gmail.com>