### PR TITLE
Update "custom nginx configuration" section.

### DIFF
--- a/staticfile/index.html.md.erb
+++ b/staticfile/index.html.md.erb
@@ -91,9 +91,9 @@ gunzip off;
 gzip_static off;
 ```
 
-### <a id='gzip'></a> GZip Static ###
+### <a id='custom_nginx_configuration'></a> Custom Nginx Configuration ###
 
-You can customize the Nginx configuration further, by adding `nginx.conf` and/or `mime.types` to your root folder.
+You can customize the Nginx configuration further, by adding `nginx.conf` and/or `mime.types` to your root folder. (Note that if you specified an [alternate root folder](#root_folder), the files will need to be placed there.)
 
 If the buildpack detects either of these files, they will be used in place of the built-in versions.
 


### PR DESCRIPTION
It seems the section title was copy-pasted from the previous section, so I gave it the title "Custom Nginx Configuration".

Also, I was confused because I'd assumed that my `nginx.conf` should be in the same place as the root of my project folder that contains my application manifest, rather than the root directory static files are served out of. So I added a bit of documentation to clarify this.