### PR TITLE
CF client project is now `-reactor` not `-spring`

### DIFF
--- a/java/java-client.html.md.erb
+++ b/java/java-client.html.md.erb
@@ -17,13 +17,13 @@ Visit the [Cloud Foundry Java Client Library](https://github.com/cloudfoundry/cf
 Most projects need two dependencies: the Operations API and an implementation of the Client API. Refer to the following sections for more information on how to add the Cloud Foundry Java Client Library as dependencies to a Maven or Gradle project.
 
 ### <a id='maven'></a>Maven ###
-Add the `cloudfoundry-client-spring` dependency to your `pom.xml` as follows:
+Add the `cloudfoundry-client-reactor` dependency (formerly known as `cloudfoundry-client-spring`) to your `pom.xml` as follows:
 
 ```xml
 <dependencies>
     <dependency>
         <groupId>org.cloudfoundry</groupId>
-        <artifactId>cloudfoundry-client-spring</artifactId>
+        <artifactId>cloudfoundry-client-reactor</artifactId>
         <version>2.0.0.BUILD-SNAPSHOT</version>
     </dependency>
     <dependency>
@@ -72,11 +72,11 @@ The artifacts can be found in the Spring release and snapshot repositories:
 ```
 
 ### <a id='gradle'></a>Gradle ###
-Add the `cloudfoundry-client-spring` dependency to your `build.gradle` file as follows:
+Add the `cloudfoundry-client-reactor` dependency to your `build.gradle` file as follows:
 
 ```
 dependencies {
-    compile 'org.cloudfoundry:cloudfoundry-client-spring:2.0.0.BUILD-SNAPSHOT'
+    compile 'org.cloudfoundry:cloudfoundry-client-reactor:2.0.0.BUILD-SNAPSHOT'
     compile 'org.cloudfoundry:cloudfoundry-operations:2.0.0.BUILD-SNAPSHOT'
     compile 'io.projectreactor:reactor-core:2.5.0.BUILD-SNAPSHOT'
     compile 'io.projectreactor:reactor-netty:2.5.0.BUILD-SNAPSHOT'


### PR DESCRIPTION
Update docs following https://github.com/cloudfoundry/cf-java-client/commit/2d1d29c7aaa1d24b41b85cbc5d9aa0f9b91061bf . 

Note also that the old instructions (accessing the `-spring` project) fail; even though the binaries are still in the repo they assume version information for `io.projectreactor:reactor-netty` which presumably was defined in a dependency but is no longer.

I have tested the deps and they work nicely, but I have not tried the java code.