### PR TITLE
Fix typo in rails_serve_static_assets gem name

### DIFF
--- a/ruby/ruby-tips.html.md.erb
+++ b/ruby/ruby-tips.html.md.erb
@@ -315,15 +315,16 @@ Example:
 $ cf scale sidekiq-worker -i 2
 </pre>
 
-## <a id='rails-4'></a>Use rails\_serv\_static\_assets on Rails 4 ##
+## <a id='rails-4'></a>Use rails\_serve\_static\_assets on Rails 4 ##
 
 By default Rails 4 returns a 404 if an asset is not handled via an external
 proxy such as Nginx.
-The `rails_serve_static_assets` gem enables your Rails server to deliver
+The <a href="https://rubygems.org/gems/rails_serve_static_assets">`rails_serve_static_assets`</a>
+gem enables your Rails server to deliver
 static assets directly, instead of returning a 404.
 You can use this capability to populate an edge cache CDN or serve files
 directly from your web application.
-The `rails_serv_static_assets` gem enables this behavior by setting the
+The gem enables this behavior by setting the
 `config.serve_static_assets` option to `true`, so you do not need to
 configure it manually.
 


### PR DESCRIPTION
And link to the RubyGems page for it.