### PR TITLE
Remove non-functional wordpress example from PHP buildpack docs

### DIFF
--- a/php/index.html.md.erb
+++ b/php/index.html.md.erb
@@ -72,7 +72,6 @@ Here are some example applications that can be used with this buildpack.
   - [php-info]  This app has a basic index page and shows the output of `phpinfo()`.
   - [PHPMyAdmin]  A deployment of PHPMyAdmin that uses bound MySQL services.
   - [PHPPgAdmin] A deployment of PHPPgAdmin that uses bound PostgreSQL services.
-  - [Wordpress]  A deployment of WordPress that uses bound MySQL service.
   - [Drupal] A deployment of Drupal that uses bound MySQL service.
   - [CodeIgniter]  CodeIgniter tutorial application running on CF.
   - [Stand Alone]  An example which runs a standalone PHP script.
@@ -125,7 +124,6 @@ The Cloud Foundry PHP Buildpack is released under version 2.0 of the [Apache Lic
 [php-info]:https://github.com/dmikusa-pivotal/cf-ex-php-info
 [PHPMyAdmin]:https://github.com/dmikusa-pivotal/cf-ex-phpmyadmin
 [PHPPgAdmin]:https://github.com/dmikusa-pivotal/cf-ex-phppgadmin
-[Wordpress]:https://github.com/dmikusa-pivotal/cf-ex-worpress
 [Drupal]:https://github.com/dmikusa-pivotal/cf-ex-drupal
 [CodeIgniter]:https://github.com/dmikusa-pivotal/cf-ex-code-igniter
 [Stand Alone]:https://github.com/dmikusa-pivotal/cf-ex-stand-alone


### PR DESCRIPTION
- This Wordpress sample app does not work anymore, so we're removing it from the docs.

[#128896127]

Signed-off-by: Sam Smith <sesmith177@gmail.com>