### PR TITLE
Remove 'Additional Ruby Buildpack Information'

### DIFF
--- a/ruby/ruby-tips.html.md.erb
+++ b/ruby/ruby-tips.html.md.erb
@@ -328,19 +328,6 @@ The gem enables this behavior by setting the
 `config.serve_static_assets` option to `true`, so you do not need to
 configure it manually.
 
-## <a id='buildpack'></a>Additional Ruby Buildpack Information ##
-
-For information about using and extending the Ruby buildpack in Cloud Foundry,
-see the [ruby-buildpack GitHub repo](https://github.com/cloudfoundry/ruby-buildpack).
-
-You can find current information about this buildpack on the Ruby buildpack
-[release page](https://github.com/cloudfoundry/ruby-buildpack/releases) in
-GitHub.
-
-The buildpack uses a default Ruby version of `2.2.2`.
-To override this value for your app, add a Ruby declaration in the Gemfile.
-This also applies to using a JRuby interpreter.
-
 ## <a id='env-var'></a>Environment Variables ##
 
 You can access environments variable programmatically. For example, you can


### PR DESCRIPTION
- This section is not very informative and the default Ruby version is
way out of date.

[#130455827]

Signed-off-by: Sam Smith <sesmith177@gmail.com>