### PR TITLE
require Procfile for Python apps in CF >= 245

### DIFF
--- a/python/index.html.md.erb
+++ b/python/index.html.md.erb
@@ -46,7 +46,7 @@ The Python buildpack does not generate a [default start command](../../devguide/
 
 To stage with the Python buildpack and start an application, do one of the following:
 
-- Supply a Procfile. For more information about Procfiles, see the [Configuring a Production Server](../prod-server.html) topic. The following example Procfile specifies `gunicorn` as the start command for a web app running on Gunicorn:
+- **[Temporarily required](https://www.pivotaltracker.com/n/projects/966314/stories/132190561) for Cloud Foundry 245+:** Supply a Procfile. For more information about Procfiles, see the [Configuring a Production Server](../prod-server.html) topic. The following example Procfile specifies `gunicorn` as the start command for a web app running on Gunicorn:
 
     ```
     web: gunicorn SERVER-NAME:APP-NAME


### PR DESCRIPTION
Workaround to [this bug](https://www.pivotaltracker.com/n/projects/966314/stories/132190561). Would be great to be able to revert this soon, but I personally think it's worth putting it in for now, as people on my team get bitten by it regularly.

/cc @jberkhahn @utako 