### PR TITLE
Make it clear that vendoring is optional

### DIFF
--- a/python/index.html.md.erb
+++ b/python/index.html.md.erb
@@ -62,7 +62,7 @@ To stage with the Python buildpack and start an application, do one of the follo
 
 ## <a id='vendoring'></a>Vendor App Dependencies ##
 
-As stated in the [Disconnected Environments documentation](https://github.com/cf-buildpacks/buildpack-packager/blob/master/doc/disconnected_environments.md), your application must vendor its dependencies.
+If you are deploying in an environment that is disconnected from the Internet, your application [must vendor its dependencies](https://github.com/cf-buildpacks/buildpack-packager/blob/master/doc/disconnected_environments.md).
 
 For the Python buildpack, use `pip`:
 


### PR DESCRIPTION
As I understand it, vendoring is only required when disconnected from the Internet.

The previous wording implied that it was mandatory for all users. 

Ideally we wouldn't ask users to do anything they don't need to do. One of my colleagues, who is new to Cloud Foundry, got sent down a bit of a rabbithole trying to get the vendoring steps to work when he didn't need to.