### PR TITLE
Fix DATABASE_URL docs

### DIFF
--- a/ruby/ruby-environment.html.md.erb
+++ b/ruby/ruby-environment.html.md.erb
@@ -5,8 +5,8 @@ owner: Buildpacks
 
 <strong><%= modified_date %></strong>
 
-<%=vars.product_full%> provides configuration information to applications through environment variables. 
-This topic describes the additional environment variables provided by the Ruby buildpack. 
+<%=vars.product_full%> provides configuration information to applications through environment variables.
+This topic describes the additional environment variables provided by the Ruby buildpack.
 
 For more information about the standard environment variables provided by <%=vars.product_full%>, see the [Cloud Foundry Environment Variables](../../devguide/deploy-apps/environment-variable.html) topic.
 
@@ -37,8 +37,8 @@ For more information, see this [blog post](https://blog.pivotal.io/pivotal-cloud
   </tr>
   <tr>
     <td><code>DATABASE_URL</code></td>
-    <td>The Ruby buildpack examines the <code>database_uri</code> for bound services to see if they match known database types. If known relational database services are bound to the application, the buildpack sets the <code>DATABASE_URL</code> environment variable as the first services in the list.
-<br><br>	 
+    <td>Cloud Foundry examines the <code>database_uri</code> for bound services to see if they match known database types. If known relational database services are bound to the application, then the <code>DATABASE_URL</code> environment variable is set to the first services in the list.
+<br><br>
 If your application requires that <code>DATABASE_URL</code> is set to the connection string for your service, and Cloud Foundry does not set it, use the Cloud Foundry Command Line Interface (cf CLI) <code>cf set-env</code> command to set this variable manually. Example: <pre class='terminal'>$ cf set-env my_app_name DATABASE_URL mysql://ab:ab@cd.example.com:33/ab_cd</pre></td>
   </tr>
   <tr>
@@ -55,7 +55,7 @@ If your application requires that <code>DATABASE_URL</code> is set to the connec
   </tr>
   <tr>
     <td><code>RUBYOPT</code></td>
-    <td>Defines command-line options 
+    <td>Defines command-line options
 passed to Ruby interpreter. Example: <code>RUBYOPT: -I/home/vcap/app/vendor/bundle/ruby/1.9.1/gems/bundler-1.3.2/lib -rbundler/setup</code></td>
   </tr>
 </table>

--- a/ruby/ruby-service-bindings.html.md.erb
+++ b/ruby/ruby-service-bindings.html.md.erb
@@ -17,8 +17,8 @@ the `VCAP_SERVICES` environment variable by name, tag, or label.
 
 ## <a id='vcap-services-defines-database-url'></a>VCAP\_SERVICES defines DATABASE\_URL ##
 
-At runtime, the Ruby buildpack creates a `DATABASE_URL` environment variable
-for every Ruby application based on the
+At runtime, Cloud Foundry creates a `DATABASE_URL` environment variable
+for every application based on the
 [VCAP_SERVICES](../../devguide/deploy-apps/environment-variable.html#VCAP-SERVICES) environment variable.
 
 Example VCAP_SERVICES:
@@ -36,12 +36,12 @@ Example VCAP_SERVICES:
       ]
     }
 
-Based on this `VCAP_SERVICES`, the Ruby buildpack creates the following
+Based on this `VCAP_SERVICES`, Cloud Foundry creates the following
 `DATABASE_URL` environment variable:
 
     DATABASE_URL = postgres://exampleuser:examplepass@babar.elephantsql.com:5432/exampledb
 
-The Ruby buildpack uses the structure of the `VCAP_SERVICES` environment
+Cloud Foundry uses the structure of the `VCAP_SERVICES` environment
 variable to populate `DATABASE_URL`.
 Any service containing a JSON object with the following form will be recognized
 by Cloud Foundry as a candidate for `DATABASE_URL`:

--- a/ruby/ruby-tips.html.md.erb
+++ b/ruby/ruby-tips.html.md.erb
@@ -375,11 +375,9 @@ For information about using this variable, see http://blog.cloudfoundry.com/2012
 
 ### <a id='DATABASE-URL'></a>DATABASE_URL ###
 
-The Ruby buildpack looks at the database\_uri for bound services to see if they
+Cloud Foundry looks at the database\_uri for bound services to see if they
 match known database types.
-If there are known relational database services bound to the app, the
-buildpack sets up the DATABASE_URL environment variable with the first one in
-the list.
+If there are known relational database services bound to the app, the DATABASE_URL environment variable is set using the first match in the list.
 
 If your app depends on DATABASE\_URL being set to the connection string
 for your service, and Cloud Foundry does not set it, you can set this variable


### PR DESCRIPTION
- Cloud Foundry creates the environment variable, not the buildpack

[#136783989]

Signed-off-by: Sam Smith <sesmith177@gmail.com>