### PR TITLE
Update docs to add custom trusted certs

### DIFF
--- a/binary/index.html.md.erb
+++ b/binary/index.html.md.erb
@@ -60,7 +60,7 @@ func main() {
 }
 ```
 
-Your binary should run without any additional runtime dependencies on the 
+Your binary should run without any additional runtime dependencies on the
 cflinuxfs2 or lucid64 root filesystem (rootfs).
 Any such dependencies should be statically linked to the binary.
 
@@ -90,8 +90,8 @@ To run docker on Mac OS X, we recommend [boot2docker](http://boot2docker.io/).
 
 ## <a id='bosh_trusted_cert'></a>BOSH Configured Custom Trusted Certificate Support ##
 
-Certificates deployed through [BOSH configured custom trusted certificates](http://bosh.io/docs/trusted-certs.html) exist in the 
-`/etc/ssl/certs` directory and can be used by binary applications.
+Your platform operator can configure the platform to [add the custom certificates into the application container](https://docs.cloudfoundry.org/adminguide/trusted-system-certificates.html).
+The custom trusted certificates will be added to the `/etc/ssl/certs` directory and can be used by binary applications.
 
 ## <a id='help_support'></a>Help and Support ##
 

--- a/go/index.html.md.erb
+++ b/go/index.html.md.erb
@@ -211,8 +211,7 @@ the `http_proxy` and/or `https_proxy` environment variables. For more informatio
 
 ## <a id='bosh_trusted_cert'></a>BOSH Configured Custom Trusted Certificate Support ##
 
-Go uses certificates stored in `/etc/ssl/certs` and supports [BOSH configured custom trusted certificates](http://bosh.io/docs/trusted-certs.html) with no additional configuration necessary. 
-
+Go uses certificates stored in `/etc/ssl/certs`. Your platform operator can configure the platform to [add the custom certificates into the application container](https://docs.cloudfoundry.org/adminguide/trusted-system-certificates.html).
 ## <a id='help_support'></a>Help and Support ##
 
 Join the #buildpacks channel in our [Slack community] (http://slack.cloudfoundry.org/) if you need any further assistance.

--- a/php/index.html.md.erb
+++ b/php/index.html.md.erb
@@ -100,7 +100,8 @@ the [Proxy Usage Docs](http://docs.cloudfoundry.org/buildpacks/proxy-usage.html)
 
 ## <a id='bosh_trusted_cert'></a>BOSH Configured Custom Trusted Certificate Support ##
 
-For versions of PHP 5.6.0 and later, the default certificate location is `/usr/lib/ssl/certs`, which symlinks to `/etc/ssl/certs` and supports [BOSH configured custom trusted certificates](http://bosh.io/docs/trusted-certs.html) out of the box. 
+For versions of PHP 5.6.0 and later, the default certificate location is `/usr/lib/ssl/certs`, which symlinks to `/etc/ssl/certs`.
+Your platform operator can configure the platform to [add the custom certificates into the application container](https://docs.cloudfoundry.org/adminguide/trusted-system-certificates.html).
 
 ## <a id='help_support'></a>Help and Support ##
 

--- a/python/index.html.md.erb
+++ b/python/index.html.md.erb
@@ -93,7 +93,7 @@ the `http_proxy` and `https_proxy` environment variables. For more information, 
 
 ## <a id='bosh_trusted_cert'></a>BOSH Configured Custom Trusted Certificate Support ##
 
-Versions of Python 2.7.9 and later use certificates stored in `/etc/ssl/certs` and support [BOSH configured custom trusted certificates](http://bosh.io/docs/trusted-certs.html) out of the box. 
+Versions of Python 2.7.9 and later use certificates stored in `/etc/ssl/certs`. Your platform operator can configure the platform to [add the custom certificates into the application container](https://docs.cloudfoundry.org/adminguide/trusted-system-certificates.html).
 
 ## <a id='help_support'></a>Help and Support ##
 

--- a/ruby/index.html.md.erb
+++ b/ruby/index.html.md.erb
@@ -125,7 +125,7 @@ the [Proxy Usage Docs](http://docs.cloudfoundry.org/buildpacks/proxy-usage.html)
 
 ## <a id='bosh_trusted_cert'></a>BOSH Configured Custom Trusted Certificate Support ##
 
-Ruby uses certificates stored in `/etc/ssl/certs` and supports [BOSH configured custom trusted certificates](http://bosh.io/docs/trusted-certs.html) out of the box. 
+Ruby uses certificates stored in `/etc/ssl/certs`. Your platform operator can configure the platform to [add the custom certificates into the application container](https://docs.cloudfoundry.org/adminguide/trusted-system-certificates.html).
 
 ## <a id='help_support'></a>Help and Support ##
 


### PR DESCRIPTION
The current documentation says that the buildpack will automatically
include the certificates configured in bosh using [1] in the
director.trusted_certs property of the bosh director.

But this does not appear to be the case. We were not able to find any
logic related to implement such behaviour, and it does violate the
principle of the container, where the staging or runtime will not be
able to access the Host VM filesystem. We tested it and it does not seem
to work.

Instead, CF provides two strategies to inject custom certs into the
application container, as described in [2], by setting the CF manifest
properties by either setting cflinuxfs2-rootfs.trusted_certs or
diego.rep.trusted_certs.

This second approach does work[3][4] and makes sense to be the
recommeded way.

In this PR we update the corresponding buildpack documentation to point
to the right configuration.

[1] http://bosh.io/docs/trusted-certs.html
[2] https://docs.cloudfoundry.org/adminguide/trusted-system-certificates.html
[3] https://github.com/cloudfoundry/cflinuxfs2-release/blob/master/jobs/cflinuxfs2-rootfs-setup/templates/pre-start#L16-L41
[4] https://github.com/cloudfoundry/diego-release/blob/21a42ca5ddbfb784598abb35597cf44477f8ae27/jobs/rep/templates/rep_ctl.erb#L54-L67