### PR TITLE
missing indents

### DIFF
--- a/proxy-usage.html.md.erb
+++ b/proxy-usage.html.md.erb
@@ -15,8 +15,8 @@ The binary buildpack will not use a proxy because it does not use the internet a
 ~~~yaml
 ---
   env:
-  http_proxy: http://proxy-site.com:3000
-  https_proxy: https://proxy-site.com:3003
+    http_proxy: http://proxy-site.com:3000
+    https_proxy: https://proxy-site.com:3003
 ~~~
 
 __Note:__ Whilst many applications will use the `http_proxy` and `https_proxy`


### PR DESCRIPTION
It appears that the proxy variables should be under the env entry and not beside it.