### PR TITLE
discourage spring "fully executable jars"

### DIFF
--- a/java/getting-started-deploying-apps/gsg-spring.html.md.erb
+++ b/java/getting-started-deploying-apps/gsg-spring.html.md.erb
@@ -59,6 +59,7 @@ The table lists build script information for Gradle and Maven and provides docum
 
 <%= yield_for_code_snippet from: 'cloudfoundry-samples/pong_matcher_spring', at: 'gsg-spring-s3' %>
 
+<p class="note"><strong>Note</strong>: Make sure you are not building <a href="https://docs.spring.io/spring-boot/docs/current/reference/html/deployment-install.html">fully executable jars</a> because application push may fail.</p>
 
 ### Step 2: Allocate Sufficient Memory ###
 


### PR DESCRIPTION
The CF jenkins plugin chokes on them because the jar is malformed