### PR TITLE
On Staticfile page, small edit to help people find config implementation details

### DIFF
--- a/staticfile/index.html.md.erb
+++ b/staticfile/index.html.md.erb
@@ -108,11 +108,11 @@ urls: hello.example.com
 
 ## <a id='configure-and-push'></a>Configuring the Buildpack and Pushing the App
 
-This section describes various ways you can configure the Staticfile buildpack options and how to push your Staticfile app.
+This section describes ways you can configure the Staticfile buildpack options and how to push your Staticfile app.
 
 ### <a id='config-options'></a>Configuration Options
 
-This table describes some of the aspects of the Staticfile buildpack that you can configure.
+This table describes aspects of the Staticfile buildpack that you can configure using the <a href='config-process'>details in the next table</a>.
 
 <table border='1' class='nice'>
 <tr>


### PR DESCRIPTION
When reading the config option descriptions table, it's easy to feel a bit confused and wonder how to actually apply the options, so this is a small tip to look at the table below. It could be even better for these two tables to be integrated together in some fashion ([dropped a note in #cf-docs to suggest this](https://cloudfoundry.slack.com/archives/C03B0T0D5/p1504914459000085)) - this is just a small suggestion to help readers without requiring a big refactor.