### PR TITLE
Delete .cfignore and v3-push warning

### DIFF
--- a/use-multiple-buildpacks.html.md.erb
+++ b/use-multiple-buildpacks.html.md.erb
@@ -34,7 +34,6 @@ For more information about V3 commands, see the [Using Experimental cf CLI Comma
 * `v3-push` currently only supports a subset of features of `push`. In particular, it does not support the following:
   * application manifests
   * flags to set the stack or modify the default mapped route 
-  * exclusions from a `.cfignore` file
 * If you use an application manifest, you cannot include the `buildpack` key or future pushes will not function properly.
 * You can use the following commands to update the configuration of an application started with `v3-push`: 
   * `map-route`


### PR DESCRIPTION
Looks like .cfignore has been honored since https://github.com/cloudfoundry/cli/commit/46f01211f40f89fae726af989e0adbd64e165eac