### PR TITLE
Fix link to the memory section

### DIFF
--- a/node/node-tips.html.md.erb
+++ b/node/node-tips.html.md.erb
@@ -53,7 +53,7 @@ app should listen on. To also run your app locally, set the default port as `300
 app.listen(process.env.PORT || 3000);
 ~~~
 
-## <a id='port'></a> Low Memory Environments ##
+## <a id='memory'></a> Low Memory Environments ##
 
 When running node apps, you might notice that instances are occasionally
 restarted due to memory constraints. Node does not know how much memory it is


### PR DESCRIPTION
`id='port'` is already used by the previous section