### PR TITLE
Add infos about x-forward limitation

### DIFF
--- a/java/index.html.md.erb
+++ b/java/index.html.md.erb
@@ -82,3 +82,15 @@ The Java buildpack prints a histogram of the heap to the logs when the JVM encou
 The Cloud Foundry default Java buildpack is currently 3.x to allows time for apps to be upgrade to 4.x.
 
 For more information, see [Java buildpack 4.0](https://www.cloudfoundry.org/just-released-java-buildpack-4-0/).
+
+## <a id='header-constrains'></a> Limitation with X-Forward headers
+As a CF provider, our Gorouter IPs run in the 100.64 range. Tomcat's RemoteIPValve by default only trusts private IP ranges for headers like X-Forwarded-For and X-Forwarded-Proto.
+To trust also these IPs, we configure the Tomcat internalProxies list with the corresponding RemoteIPValve as standard for all applications that use the latest system buildpack. If you use your own online buildpack please make sure your add our configuration accordingly. This can be done via setting JBP_CONFIG_TOMCAT environment variable accordingly:
+<pre>
+JBP_CONFIG_TOMCAT: '{ tomcat: { external_configuration_enabled: true }, external_configuration: { repository_root: "https://tomcat-external-configuration.lyra-836.appcloud.swisscom.com" } }'
+</pre>
+
+If you overwrite this environment variable with your own special configuraiton, please make sure that you also include our settings to avoid problems with the mentioned headers.
+For full understanding - our external configuration addes the following line to your server.xml configuration:
+<Valve className='org.apache.catalina.valves.RemoteIpValve' protocolHeader='x-forwarded-proto' internalProxies="10\.\d{1,3}\.\d{1,3}\.\d{1,3}|192\.168\.\d{1,3}\.\d{1,3}|169\.254\.\d{1,3}\.\d{1,3}|127\.\d{1,3}\.\d{1,3}\.\d{1,3}|172\.1[6-9]{1}\.\d{1,3}\.\d{1,3}|172\.2[0-9]{1}\.\d{1,3}\.\d{1,3}|172\.3[0-1]{1}\.\d{1,3}\.\d{1,3}|100\.104\.\d{1,3}\.\d{1,3}"/>
+


### PR DESCRIPTION
After the migration, we will face errors with the x-forward for IP's as the new IP's are not trusted by default. This adds the information for the user. 