### PR TITLE
Documentation has incorrect link for the binary buildpack

### DIFF
--- a/binary/index.html.md.erb
+++ b/binary/index.html.md.erb
@@ -16,7 +16,7 @@ buildpack.
 For example:
 
 <pre class="terminal">
-$ cf push my_app -b https://github.com/cloudfoundry/binary_buildpack.git
+$ cf push my_app -b https://github.com/cloudfoundry/binary-buildpack.git
 </pre>
 
 You can provide Cloud Foundry with the shell command to execute your binary in


### PR DESCRIPTION
I was trying the link as is from the documentation i.e. 

`cf push test-app -b https://github.com/cloudfoundry/binary_buildpack.git`  and got errors

```
 Downloading app package...
   Downloaded app package (2.3M)
   Failed to clone git repository at https://github.com/cloudfoundry/binary_buildpack.git
   Exit status 1
``` 

I realize the `_` should be a `-` so the link is `cf push my_app -b https://github.com/cloudfoundry/binary-buildpack.git`