### PR TITLE
point to nginx buildpack for custom configuration

### DIFF
--- a/staticfile/index.html.md.erb
+++ b/staticfile/index.html.md.erb
@@ -322,6 +322,12 @@ if you use <a href="https://support.cloudflare.com/hc/en-us/articles/200170416">
     </tr>
 
     <tr>
+    <td>specify additional MIME types</td>
+    <td>add a <code><strong>mime.types</strong></code> file to your root folder, or to the alternate root folder if you specified one.</td>
+    <td><a href="https://www.nginx.com/resources/wiki/start/topics/examples/full/#mime-types">NGINX documentation</a></td>
+    </tr>
+
+    <tr>
     <td>make additional configuration changes to NGINX</td>
     <td>use the NGINX Buildpack instead of the Staticfile buildpack.</td>
     <td><a href="/buildpacks/nginx/">NGINX Buildpack</a></td>

--- a/staticfile/index.html.md.erb
+++ b/staticfile/index.html.md.erb
@@ -220,8 +220,7 @@ and <a href="http://nginx.org/en/docs/http/ngx_http_gunzip_module.html">gunzip</
 
 <tr>
   <td>Custom NGINX configuration</td>
-  <td>Additional NGINX configuration can be applied, such as mapping file extensions to mime types.
-      See the <a href="https://www.nginx.com/resources/wiki/start/topics/examples/full/">NGINX documentation</a> for examples.</td>
+  <td>If you require additional custom NGINX configuration you should use the <a href="buildpacks/nginx/">NGINX Buildpack</a></td>
 </tr>
 </table>
 
@@ -324,8 +323,8 @@ if you use <a href="https://support.cloudflare.com/hc/en-us/articles/200170416">
 
     <tr>
     <td>make additional configuration changes to NGINX</td>
-    <td>add <code><strong>nginx.conf</strong></code> and <code><strong>mime.types</strong></code> files to your root folder, or to the alternate root folder if you specified one.</td>
-    <td><a href="https://www.nginx.com/resources/wiki/start/topics/examples/full/">NGINX documentation</a></td>
+    <td>use the NGINX Buildpack instead of the Staticfile buildpack.</td>
+    <td><a href="/buildpacks/nginx/">NGINX Buildpack</a></td>
     </tr>
     </table>
 


### PR DESCRIPTION
Using a custom `nginx.conf` in Staticfile buildpack is deprecated as per: https://github.com/cloudfoundry/staticfile-buildpack/commit/9c9ae2c1f27a450bf73c87b02261f2813f45d9db

This PR changes the documentation to reflect that and point users to the NGINX buildpack if they require this functionality.