### PR TITLE
reflect required path in Staticfile

### DIFF
--- a/staticfile/index.html.md.erb
+++ b/staticfile/index.html.md.erb
@@ -203,7 +203,7 @@ and <a href="http://nginx.org/en/docs/http/ngx_http_gunzip_module.html">gunzip</
     <b>Content</b>:
     <code>add_header X-MySiteName BestSiteEver;</code><br><br>
 
-    <li>Set the <code>location_include</code> variable in your <b>Staticfile</b> to the  path of the file from the previous step:<br>
+    <li>Set the <code>location_include</code> variable in your <b>Staticfile</b> to the path of the file from the previous step (relative to <code>nginx/conf</code>):<br>
 
     <code style="width: 100%">
     ...<br>


### PR DESCRIPTION
Previously it was incorrectly stated:

> Set the location_include variable in your Staticfile to the path of the file from the previous step:

As the path from the previous step was `nginx/conf/includes/custom_header.conf` and the path in `Staticfile` is `includes/*.conf` 

This PR reflects that the required path is relative to `nginx/conf`