### PR TITLE
Update docs for using multiple buildpacks

### DIFF
--- a/use-multiple-buildpacks.html.md.erb
+++ b/use-multiple-buildpacks.html.md.erb
@@ -19,13 +19,10 @@ To push an application with multiple buildpacks using the Cloud Foundry Command 
   <pre class="terminal">$ cf version
   </pre>
   For more information about upgrading the cf CLI, see [Installing the cf CLI](../cf-cli/install-go-cli.html).
-1. Push the application with the binary buildpack with the `--no-start` flag:
-  <pre class="terminal">$ cf push YOUR-APP --no-start -b binary_buildpack</pre>
-  This command pushes the application but does not start it.
-1. Upgrade the application to multiple buildpacks, and specify the buildpacks:
+1. To push your app with multiple buildpacks, specify each buildpack with a `-b` flag. The last buildpack in order will be the *final* buildpack which is able to modify the launch environment and set the start command. For more information on multi-buildpack order see the [Understanding Buildpacks](understand-buildpacks.html) topic:
   <pre class="terminal">
-  $ cf push YOUR-APP -b BUILDPACK-NAME-1 -b BUILDPACK-NAME-2
+  $ cf push YOUR-APP -b BUILDPACK-NAME-1 -b BUILDPACK-NAME-2 ... -b FINAL-BUILDPACK-NAME
   </pre>
-  This command changes the buildpack and starts the application. To see a list of available buildpacks, run `cf buildpacks`.
+To see a list of available buildpacks, run `cf buildpacks`.
 
 For more information about using the cf CLI, see the [Cloud Foundry Command Line Interface](../cf-cli/index.html) topic.


### PR DESCRIPTION
- Remove section about running cf push --no-start.
  This is not the workflow anymore.
- Add tidbit about final buildpack and link to Understanding Buildpacks topic

[#160821947]