### PR TITLE
Correct documented buildpacks.yml filename

### DIFF
--- a/nginx/index.html.md.erb
+++ b/nginx/index.html.md.erb
@@ -28,7 +28,7 @@ The NGINX webserver setup includes the following:
 * A root folder for all static web content
 * A MIME type configuration file
 * An NGINX configuration file
-* A `buildpack.yml` YAML file that defines the version of NGINX to use
+* A `buildpack.yml` YAML file that defines the version of NGINX to use, [for example](https://github.com/cloudfoundry/nginx-buildpack/blob/master/fixtures/mainline/buildpack.yml)
 
 You should make any custom configuration changes based on these default files to ensure compatibility with the buildpack.
 

--- a/nginx/index.html.md.erb
+++ b/nginx/index.html.md.erb
@@ -28,7 +28,7 @@ The NGINX webserver setup includes the following:
 * A root folder for all static web content
 * A MIME type configuration file
 * An NGINX configuration file
-* A `buildpacks.yml` YAML file that defines the version of NGINX to use
+* A `buildpack.yml` YAML file that defines the version of NGINX to use
 
 You should make any custom configuration changes based on these default files to ensure compatibility with the buildpack.
 


### PR DESCRIPTION
RE: #219; The documention currently references the incorrect filename for `buildpack.yml`, this PR corrects the filename from `buildpacks.yml` -> `buildpack.yml`.

As seen, I think linking to an example format for this file would be helpful.

The correct filename reference can be seen here: https://github.com/cloudfoundry/nginx-buildpack/blob/3d84c52ecd32da531ddaa1a1cc61b5d247f3277c/src/nginx/supply/supply.go#L118