### PR TITLE
Fix broken link

### DIFF
--- a/go/index.html.md.erb
+++ b/go/index.html.md.erb
@@ -185,7 +185,7 @@ Set the `GO_LINKER_SYMBOL` and `GO_LINKER_VALUE` in the application's configurat
 This can be used to embed the commit SHA or other build-specific data directly
 into the compiled executable.
 
-For example usage, see the relevant [fixture app](https://github.com/cloudfoundry/go-buildpack/tree/master/fixtures/go16_ldflags/src/go_app).
+For example usage, see the relevant [fixture app](https://github.com/cloudfoundry/go-buildpack/tree/master/fixtures/go_ldflags/src/go_app).
 
 ## <a id='c_dependencies'></a>C Dependencies ##
 


### PR DESCRIPTION
For the "Pass a Symbol and String to the Linker" section, we fixed a broken link and provided a new link to a sample app.