### PR TITLE
Fixed wrong link to go sample app

### DIFF
--- a/go/index.html.md.erb
+++ b/go/index.html.md.erb
@@ -53,8 +53,8 @@ If you are using [godep](https://github.com/tools/godep) to package your depende
 
 When using godep, you can fix your Go version in `GoVersion` key of the `Godeps/Godeps.json` file.
 
-#### <a id='godeps_1.6'></a>Go 1.6 ####
-* [Sample Go 1.6 app](https://github.com/cloudfoundry/go-buildpack/tree/master/fixtures/go16/src/go_app)
+#### <a id='godeps_1.6'></a>Go Sample App ####
+* [Sample Go app](https://github.com/cloudfoundry/go-buildpack/tree/master/fixtures/go_app)
 
 An example `Godeps/Godeps.json`:
 


### PR DESCRIPTION
While playing around with the go buildpack I found this wrong link and fixed it.