### PR TITLE
Adding a note for new versions of PIP

### DIFF
--- a/python/index.html.md.erb
+++ b/python/index.html.md.erb
@@ -78,9 +78,10 @@ $ cd YOUR-APP-DIR
 $ mkdir -p vendor
 
 # vendors all the pip *.tar.gz into vendor/
+# Newer versions of pip have a download subcommand. Use that instead.
 $ pip install --download vendor -r requirements.txt --no-binary :all:
 </pre>
-
+ 
 `cf push` uploads your vendored dependencies. The buildpack installs them directly from the `vendor/` directory.
 
 <p class="note"><strong>Note</strong>: To ensure proper installation of dependencies, we recommend non-binary vendored dependencies. The above <code>pip install</code> command achieves this.</p>


### PR DESCRIPTION
New version of pip has a download sub command and does now have the download flag option. So adding a note of caution for users.