### PR TITLE
Suggest having sample push show a jar file rather than war.

### DIFF
--- a/java/getting-started-deploying-apps/gsg-spring.html.md.erb
+++ b/java/getting-started-deploying-apps/gsg-spring.html.md.erb
@@ -125,7 +125,7 @@ Run `cf login -a API-ENDPOINT`, enter your login credentials, and select a space
 
 <p class="note"><strong>Note</strong>: You must use the cf CLI to deploy apps.</p>
 
-From the root directory of your application, run `cf push APP-NAME -p PATH-TO-FILE.war` to deploy your application.
+From the root directory of your application, run `cf push APP-NAME -p PATH-TO-FILE.jar` to deploy your application.
 
 <p class="note"><strong>Note</strong>: Most Spring apps include an artifact, such as a <code>.jar</code>, <code>.war</code>, or <code>.zip</code> file. You must include the path to this file in the <code>cf push</code> command using the <code>-p</code> option if you do not declare the path in the <code>applications</code> block of the manifest file. The example shows how to specify a path to the <code>.war</code> file for a Spring app. Refer to the <a href="../java-tips.html">Tips for Java Developers</a> topic for CLI examples for specific build tools, frameworks, and languages that create an app with an artifact.</p>
 


### PR DESCRIPTION
jars are more common and showing the example with "war" might make newer folks wonder if a war is preferred.