### PR TITLE
Document the "num_threads" parallel install option

### DIFF
--- a/r/index.html.md.erb
+++ b/r/index.html.md.erb
@@ -55,12 +55,13 @@ As of v0.0.5, the following packages are provided by the buildpack:
 - forecast
 - shiny
 
-To specify additional packages needed by your app, provide the CRAN mirror and names of the packages inside your `r.yml` file. For example:
+To specify additional packages needed by your app, provide the CRAN mirror and names of the packages inside your `r.yml` file. You can also specify the number of threads to use for parallel installation. For example:
 
 ```
 ---
 packages:
   - cran_mirror: https://cran.r-project.org
+    num_threads: 2
     packages:
       - name: stringr
       - name: jsonlite


### PR DESCRIPTION
The buildpack [looks for a `num_threads` option in the `r.yml` file](https://github.com/cloudfoundry/r-buildpack/blob/c00ad2964784206f901723ca6cac052f1915c333/src/r/supply/supply.go#L52) and [supplies it as the `Ncpus` parameter to the invocation of `install.packages()`](https://github.com/cloudfoundry/r-buildpack/blob/c00ad2964784206f901723ca6cac052f1915c333/src/r/supply/supply.go#L119). That was [implemented here](https://github.com/cloudfoundry/r-buildpack/pull/3) but not documented.

This behavior is _extremely useful_ because it speeds up staging for R apps, potentially avoiding the default 15-minute staging timeout. When this flag was configured to match the number of CPUs available on our hosts, one cloud.gov customer reported a 38% speedup of staging time.