### PR TITLE
Include information on the port

### DIFF
--- a/python/index.html.md.erb
+++ b/python/index.html.md.erb
@@ -67,6 +67,14 @@ To stage with the Python buildpack and start an application, do one of the follo
 - Specify a start command in the application manifest by setting the `command` attribute. For more information, see the [Deploying with Application Manifests](../../devguide/deploy-apps/manifest.html#start-commands) topic.
 
 
+## Running the webserver
+
+This buildpack expects the Python application to listen to port 9099.  For example, using Flask, you would do
+```
+if __name__ == "__main__":
+  app.run(host='0.0.0.0', port=9099)
+```
+
 ## <a id='vendoring'></a> Vendor App Dependencies
 
 If you are deploying in an environment that is disconnected from the Internet, your application [must vendor its dependencies](https://github.com/cf-buildpacks/buildpack-packager/blob/master/doc/disconnected_environments.md).

--- a/python/index.html.md.erb
+++ b/python/index.html.md.erb
@@ -69,11 +69,16 @@ To stage with the Python buildpack and start an application, do one of the follo
 
 ## Running the webserver
 
-This buildpack expects the Python application to listen to port 9099.  For example, using Flask, you would do
+This buildpack expects the Python application to listen to port 8080, but it is best to use the exposed `PORT` variable.  
+For example, using Flask, you would use the following to start your server on the PORT suggested by Cloud Foundry, and on 
+all network interfaces:
 ```
 if __name__ == "__main__":
-  app.run(host='0.0.0.0', port=9099)
+  port = int(os.getenv("PORT", 8080))
+  app.run(host='0.0.0.0', port=port)
 ```
+
+Note that the `PORT` variable is not visible in the GUI or the `cf env APPNAME` command, but it still exists. 
 
 ## <a id='vendoring'></a> Vendor App Dependencies
 


### PR DESCRIPTION
I had to dig for a working example to find out which port this buildpack expects me to expose.  The `host='0.0.0.0'` is  also tricky enough to include in the docs, IMHO.