### PR TITLE
Update Staticfile location instructions

### DIFF
--- a/staticfile/index.html.md.erb
+++ b/staticfile/index.html.md.erb
@@ -21,7 +21,7 @@ To find which version of NGINX the current Staticfile buildpack uses, see the [S
 
 ### <a id='staticfile'></a>Staticfile Detection
 
-If you create a file named `Staticfile` in the root directory of your app, Cloud Foundry automatically
+If you create a file named `Staticfile` and locate it in the build directory of your app, Cloud Foundry automatically
 uses the Staticfile buildpack when you push your app.
 
 The `Staticfile` file can be an empty file, or it can contain configuration settings for your app.


### PR DESCRIPTION
The Staticfile location instructions were unclear in telling users to place the file at the root because root directory implies root of the repository.  On further investigation this really means in the _build_ directory.  See this issue for more information - it instructs users to place the Staticfile in the build directory also:  https://github.com/cloudfoundry/staticfile-buildpack/issues/148