### PR TITLE
document `package main` in a subdirectory

### DIFF
--- a/go/index.html.md.erb
+++ b/go/index.html.md.erb
@@ -66,6 +66,43 @@ require (
 )
 ```
 
+#### <a id='gomod_subdirectory_main_package'></a>Push an app with a main package somewhere besides the project root ####
+
+A common project pattern is to place main packages in a subdirectory called `cmd`.
+
+For example,
+
+```bash
+$ tree app-package-name
+app-package-name
+├── cmd
+│   ├── cli
+│   │   └── main.go
+│   └── server
+│       └── main.go
+├── go.mod
+├── go.sum
+├── shared.go
+├── shared_test.go
+└── manifest.yml
+```
+
+When you configure your project like this, set the environment variable `GO_INSTALL_PACKAGE_SPEC` 
+to `$MODULE_NAME/$MAIN_PACKAGE_PATH`.
+
+So if the module name for the above `app-package-name` app is `example.com/user/app-package-name`,
+the value of `GO_INSTALL_PACKAGE_SPEC` should be `example.com/user/app-package-name/cmd/server`.
+
+If you want to put this in your `manifest.yml`, it would look something like this:
+
+```yaml
+---
+applications:
+- name: app-package-name
+  env:
+    GO_INSTALL_PACKAGE_SPEC: example.com/user/app-package-name/cmd/server
+```
+
 ### <a id='with_godep'></a>Push an App with godep ###
 If you are using [godep](https://github.com/tools/godep) to package your dependencies, make sure that you have created a valid `Godeps/Godeps.json` file in the root directory of your app by running `godep save`.
 


### PR DESCRIPTION
[#166781190](https://www.pivotaltracker.com/story/show/166781190)

We were pushing a Go app and spent a bit of time trying to figure this out.

We are not sure if this should be under the Go Modules section or some other
part of the page. We tested with Go Modules so we are putting it under that 
header. I am not sure of other packaging systems have their own way of 
specifying subdirectory main packages.

cc: @matt-royal