### PR TITLE
Removes BOSH trusted cert warning from Staticfile docs

### DIFF
--- a/node/index.html.md.erb
+++ b/node/index.html.md.erb
@@ -3,7 +3,9 @@ title: Node.js Buildpack
 owner: Buildpacks
 ---
 
+## <a id='overview'></a> Overview
 
+This topic describes how to configure and use the Node.js buildpack.
 
 Use the Node.js buildpack with Node or JavaScript apps.
 

--- a/staticfile/index.html.md.erb
+++ b/staticfile/index.html.md.erb
@@ -9,8 +9,6 @@ owner: Buildpacks
 
 This topic describes how to configure and use the Staticfile buildpack.
 
-<p class="note"><strong>Note</strong>: <a href="http://bosh.io/docs/trusted-certs.html">BOSH configured custom trusted certificates</a> are not supported by the Staticfile buildpack.</p>
-
 ### <a id='definitions'></a>Definitions
 
 **Staticfile app**: An app or content that requires no backend code other than the NGINX webserver, which the buildpack provides.


### PR DESCRIPTION
- adds overview header to Node.js docs