### PR TITLE
Non-binary needs to be "all" not "none"

### DIFF
--- a/python/index.html.md.erb
+++ b/python/index.html.md.erb
@@ -93,7 +93,7 @@ $ cd YOUR-APP-DIR
 $ mkdir -p vendor
 
 # vendors all the pip *.tar.gz into vendor/
-$ pip download -r requirements.txt --no-binary=:none: -d vendor
+$ pip download -r requirements.txt --no-binary=:all: -d vendor
 </pre>
 
 `cf push` uploads your vendored dependencies. The buildpack installs them directly from the `vendor/` directory.


### PR DESCRIPTION
The command's logic was the inverse of the explanation below.