### PR TITLE
Remove deprecated flag from custom start command

### DIFF
--- a/binary/index.html.md.erb
+++ b/binary/index.html.md.erb
@@ -106,7 +106,7 @@ This file should be in the same folder as your `.csproj` file and be marked **co
     applications:
     - name: MY-AWESOME-APP
       stack: windows
-      command: cmd /c .\MY-AWESOME-APP --server.urls=http://0.0.0.0:%PORT%
+      command: cmd /c .\MY-AWESOME-APP --urls=http://0.0.0.0:%PORT%
     ```
 
 1. Publish the project using the dotnet CLI or Visual Studio.


### PR DESCRIPTION
The current steps for pushing a .NET core app onto the v2 Windows Stack, using the `binary-buildpack` causes a failure. This change updates the `binary buildpack` documentation to remove the deprecated flag `--server.urls` from the custom start command for .NET core apps.