### PR TITLE
Removes references to CF-compatible CNBs

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,10 +15,5 @@ repository for the complete list of open source documentation repositories, as w
 
 Use this section to specify spelling of special words for buildpacks:
 
-+ **CF-compatible CNB** The original term proposed was "shimmed buildpack".
-    Do not capitalize compatible and do hyphenate CF-compatible.
-    No need to add buildpack at the end because the "B" in CNB stands for "buildpack".
-    It does not stand for "bundle" as I originally thought).
-
 + Do not use variables to represent "product-names" in these files.
   The buildpacks are not proprietary but belong to Cloud Foundry.

--- a/custom.html.md.erb
+++ b/custom.html.md.erb
@@ -209,14 +209,3 @@ The app is then deployed to Cloud Foundry, and the buildpack is cloned from the 
 <%= vars.disable_custom %>
 
 <p class="note"><strong>Note:</strong> A common development practice for custom buildpacks is to fork existing buildpacks and sync subsequent patches from upstream. To merge upstream patches to your custom buildpack, see <a href="https://help.github.com/articles/syncing-a-fork">Syncing a fork</a> in the GitHub documentation.</p>
-
-
-## <a id='cf-compat-cnb'></a> About Creating CF-compatible CNBs
-
-If you are creating a CF-compatible CNB (Cloud Foundry-compatible Cloud Native Buildpack),
-then you need to use the `cnb2cf` tool to generate the compatibility layer.
-
-This layer mediates API differences between Cloud Native Buildpacks and Cloud Foundry Buildpacks.
-For information about this tool, see [cnb2cf](https://github.com/cloudfoundry/cnb2cf) in GitHub.
-
-For general information about CNBs, see [What Are Buildpacks?](https://buildpacks.io/) in Buildpacks.io.

--- a/index.html.md.erb
+++ b/index.html.md.erb
@@ -32,18 +32,6 @@ The following topics discuss different usage scenarios for buildpacks in Cloud F
 For information about the existing buildpacks that Cloud Foundry supports, see [System Buildpacks](system-buildpacks.html).
 
 
-## <a id='cnb-buildpacks'></a> CF-compatible CNBs
-
-A Cloud Foundry-compatible Cloud Native Buildpack (CF-compatible CNB) is a bundled collection of CNBs.
-
-
-CNBs are modular buildpacks.
-Using CNBs to deploy apps leads to improved performance, informative logging, and easier
-configuration as compared to Cloud Foundry-only buildpacks.
-For general information about CNBs, see [What Are Buildpacks?](https://buildpacks.io/) in Buildpacks.io.
-
-CF-compatible CNBs include a Compatibility Layer that allows the CNBs to run on Cloud Foundry.
-
 ## <a id='sidecar-buildpacks'></a> Sidecar Buildpacks
 
 For information about deploying a sidecar buildpack, see [Sidecar Buildpack](sidecar-buildpacks.html).


### PR DESCRIPTION
This is not currently supported, and so should not be documented.

/cc @kvedurmu 