### PR TITLE
Remove beta tag from sidecar buildpacks

### DIFF
--- a/sidecar-buildpacks.html.md.erb
+++ b/sidecar-buildpacks.html.md.erb
@@ -1,5 +1,5 @@
 ---
-title: Sidecar Buildpacks (Beta)
+title: Sidecar Buildpacks
 Buildpacks owner: Buildpacks
 ---
 


### PR DESCRIPTION
These were intended to be GA last July, but the docs were not updated.

cc @dsboulder @anEXPer @elenasharma