### PR TITLE
Fix pip vendor command to match the explanation

### DIFF
--- a/python/index.html.md.erb
+++ b/python/index.html.md.erb
@@ -105,7 +105,7 @@ $ cd YOUR-APP-DIR
 $ mkdir -p vendor
 
 # vendors pip *.tar.gz into vendor/
-$ pip download -r requirements.txt --no-binary=:none: -d vendor
+$ pip download -r requirements.txt --no-binary=:all: -d vendor
 </pre>
 
 `cf push` uploads your vendored dependencies. The buildpack installs them directly from the `vendor/` directory.


### PR DESCRIPTION
The explanation is

> To ensure proper installation of dependencies, Cloud Foundry recommends non-binary vendored dependencies. However, as per the [documentation of pip](https://pip.pypa.io/en/stable/cli/pip_install/#cmdoption-no-binary)

> Do not use binary packages. [..] Accepts either “:all:” to disable all binary packages, “:none:” to empty the set (notice the colons)

i.e. to disable binary packages (wheels) and get non-binary (source) packages the command must be adapted with `:all:`. (This assumes the explanation is correct and the code was wrong)