### PR TITLE
Fix pip vendor command explanation

### DIFF
--- a/python/index.html.md.erb
+++ b/python/index.html.md.erb
@@ -110,7 +110,7 @@ $ pip download -r requirements.txt --no-binary=:none: -d vendor
 
 `cf push` uploads your vendored dependencies. The buildpack installs them directly from the `vendor/` directory.
 
-<p class="note"><strong>Note</strong>: To ensure proper installation of dependencies, <%= vars.recommended_by %> recommends non-binary vendored dependencies. The above <code>pip install</code> command achieves this.</p>
+<p class="note"><strong>Note</strong>: To ensure proper installation of dependencies, <%= vars.recommended_by %> recommends binary vendored dependencies (wheels). The above <code>pip install</code> command achieves this.</p>
 
 
 ## <a id='private-repos'></a> Private Dependency Repository

--- a/python/index.html.md.erb
+++ b/python/index.html.md.erb
@@ -104,7 +104,7 @@ For the Python buildpack, use `pip`:
 $ cd YOUR-APP-DIR
 $ mkdir -p vendor
 
-# vendors pip *.tar.gz into vendor/
+# vendors pip *.whl into vendor/
 $ pip download -r requirements.txt --no-binary=:none: -d vendor
 </pre>
 


### PR DESCRIPTION
As per the [documentation of pip](https://pip.pypa.io/en/stable/cli/pip_install/#cmdoption-no-binary)

> Do not use binary packages. [..] Accepts either “:all:” to disable all binary packages, “:none:” to empty the set (notice the colons)

i.e. the command, as it stood, installed binary packages (wheels) only and the explanation was wrong: in the buildpack you're likely to not have all relevant header files that you need for compiling the packages; better to vendor wheels instead.