### PR TITLE
Update stack-related documentation

### DIFF
--- a/stack-association.html.md.erb
+++ b/stack-association.html.md.erb
@@ -5,9 +5,7 @@ owner: Buildpacks
 
 This topic describes the stack association feature for Cloud Foundry buildpacks.
 
-<p class="note"><strong>Note</strong>: This functionality is supported as of CAPI <a href="https://github.com/cloudfoundry/capi-release/releases/tag/1.58.0">v1.58.0</a> and cf CLI  <a href="https://github.com/cloudfoundry/cli/releases/tag/v6.39.0">v6.39.0</a>.</p>
-
-<p class="note warning"><strong>Warning</strong>: To avoid security exposure, ensure that you migrate your apps and custom buildpacks to use the <code>cflinuxfs3</code> stack based on Ubuntu 18.04 (Bionic Beaver). <code>cflinuxfs2</code> is based on Ubuntu 14.04 (Trusty Tahr), which reaches end of general support (EOGS) in April 2019. </p>
+<p class="note warning"><strong>Warning</strong>: To avoid security exposure, ensure that you migrate your apps and custom buildpacks to use the <code>cflinuxfs4</code> stack based on Ubuntu 22.04 LTS (Jammy Jellyfish). <code>cflinuxfs3</code> is based on Ubuntu 18.04 (Bionic Beaver), which reaches end of standard support in April 2023. </p>
 
 ## <a id='overview'></a> Overview ##
 
@@ -17,11 +15,14 @@ Each buildpack in your deployment is associated with a stack. You can see this w
 $ cf buildpacks
 Getting buildpacks...
 
-buildpack                position   enabled   locked   filename                                             stack
-staticfile_buildpack     1          true      false    staticfile_buildpack-cached-cflinuxfs3-v1.4.29.zip   cflinuxfs3
-java_buildpack_offline   2          true      false    java-buildpack-offline-cflinuxfs3-v4.12.1.zip        cflinuxfs3
-ruby_buildpack           3          true      false    ruby_buildpack-cached-cflinuxfs3-v1.7.21.zip         cflinuxfs3
-. . . 
+position   name                                stack        enabled   locked   filename
+1          staticfile_buildpack                cflinuxfs3   true      false    staticfile_buildpack-cached-cflinuxfs3-v1.5.36.zip
+2          java_buildpack                      cflinuxfs3   true      false    java_buildpack-cached-cflinuxfs3-v4.53.zip
+3          ruby_buildpack                      cflinuxfs3   true      false    ruby_buildpack-cached-cflinuxfs3-v1.9.0.zip
+. . .
+12         ruby_buildpack                      cflinuxfs4   true      false    ruby_buildpack-cached-cflinuxfs4-v1.9.0.zip
+13         dotnet_core_buildpack               cflinuxfs4   true      false    dotnet-core_buildpack-cached-cflinuxfs4-v2.4.5.zip
+. . .
 </pre>
 
 Because of this stack association, buildpacks do not have to be uniquely named. This helps in managing similar buildpacks that are compatible with different stacks. 
@@ -56,16 +57,16 @@ When operating on buildpacks with the cf CLI, consider the following:
 
 ### <a id='examples-cli'></a> Example Scenarios 
 
-See the following examples of managing buildpacks with the cf CLI, which are applicable when running `cf update-buildpack`, `cf rename-buildpack`, or `cf delete-buildpack`:
+See the following examples of managing buildpacks with the cf CLI, which are applicable when running `cf update-buildpack` or `cf delete-buildpack`:
 
-* **Updating, renaming, or deleting a uniquely-named buildpack:**
+* **Updating or deleting a uniquely-named buildpack:**
 	* You have a single buildpack named `my-buildpack`, and it is associated with `stack_a`.  If you want to delete the buildpack, you can run `cf delete-buildpack my-buildpack`.<br><br>
 	You can also provide `-s stack_a`, but the option is not required if you have a uniquely-named buildpack.
-* **Updating, renaming, or deleting a uniquely-named buildpack that has a `nil` stack:**
+* **Updating or deleting a uniquely-named buildpack that has a `nil` stack:**
 	* You have a single buildpack named `my-buildpack`, and it is not associated with a stack.  If you want to delete the buildpack, you can run `cf delete-buildpack my-buildpack`.
-* **Updating, renaming, or deleting a buildpack when another buildpack exists with the same name, and both buildpacks have stack associations:**
+* **Updating or deleting a buildpack when another buildpack exists with the same name, and both buildpacks have stack associations:**
 	* You have two buildpacks named `my-buildpack`, one that is associated with `stack_a` and the other associated with `stack_b`. If you want to delete the buildpack that uses `stack_a`, you can run `cf delete-buildpack my-buildpack -s stack_a`.
-* **Updating, renaming, or deleting a buildpack when another buildpack exists with the same name. One buildpack has a stack association, and the other buildpack has a `nil` stack:** 
+* **Updating or deleting a buildpack when another buildpack exists with the same name. One buildpack has a stack association, and the other buildpack has a `nil` stack:**
 	* You have two buildpacks named `my-buildpack`, one associated with  `stack_a` and the other associated with no (`nil`) stack association:
 		* If you want to delete the buildpack that uses `stack_a`, you can run `cf delete-buildpack my-buildpack -s stack_a`. 
 		* If you want to delete the buildpack that is associated with the `nil` stack, run `cf delete-buildpack my-buildpack`.


### PR DESCRIPTION
* remove outdated information on cflinuxfs2, capi-release 1.58.0 (2018) and CF CLI v6
* add information on cflinuxfs4 / Ubuntu Jammy
* remove "rename-buildpack" command docu (is now "update-buildpack --rename")