### PR TITLE
Fix refence to `pip download`

### DIFF
--- a/python/index.html.md.erb
+++ b/python/index.html.md.erb
@@ -113,7 +113,7 @@ $ pip download -r requirements.txt --no-binary=:none: -d vendor
 `cf push` uploads your vendored dependencies. The buildpack installs them directly from the `vendor/` directory.
 
 <p> To ensure proper installation of dependencies, <%= vars.recommended_by %> recommends binary vendored
-dependencies (wheels). The preceding <code>pip install</code> command achieves this.</p>
+dependencies (wheels). The preceding <code>pip download</code> command achieves this.</p>
 
 
 ## <a id='private-repos'></a> Private dependency repository


### PR DESCRIPTION
Hi colleagues,

I'm 99% sure, that you are referring to the `pip download` in 

```
For the Python buildpack, use `pip`:
<pre class="terminal">
$ cd YOUR-APP-DIR
$ mkdir -p vendor
# vendors pip *.whl into vendor/
$ pip download -r requirements.txt --no-binary=:none: -d vendor
</pre>
`cf push` uploads your vendored dependencies. The buildpack installs them directly from the `vendor/` directory.

<p> To ensure proper installation of dependencies, <%= vars.recommended_by %> recommends binary vendored
dependencies (wheels). The preceding <code>pip install<HERE></code> command achieves this.</p>
```