### PR TITLE
Update memory constraints in index.html.md.erb

### DIFF
--- a/java/index.html.md.erb
+++ b/java/index.html.md.erb
@@ -54,9 +54,9 @@ Start watching /etc/ssl/certs/ca-certificates.crt
 Initialized TrustManager for /etc/ssl/certs/ca-certificates.crt
 </pre>
 
-## <a id='memory-constraints'></a> Memory constraints in Java Buildpack v4.0
+## <a id='memory-constraints'></a> Memory constraints
 
-The memory calculator in Java buildpack v4.0 accounts for the following memory regions:
+The memory calculator in the Java buildpack accounts for the following memory regions:
 
 <ul>
 <li><code>-Xmx</code>: Heap</li>
@@ -67,14 +67,9 @@ The memory calculator in Java buildpack v4.0 accounts for the following memory r
 <li><code>-XX:CompressedClassSpaceSize</code>: Compressed Class Space</li>
 </ul>
 
-Applications, which previously ran in 512&nbsp;MB or smaller containers, might no longer be able to.
 Most applications run if they use the Cloud Foundry default container size of 1&nbsp;G without any modifications.
 However, you can configure those memory regions directly as needed.
 
 The Java buildpack optimizes for all non-heap memory regions first and leaves the remainder for the heap.
 
 The Java buildpack prints a histogram of the heap to the logs when the JVM encounters a terminal failure.
-
-The Cloud Foundry default Java buildpack is currently v3.x to allows time for apps to be upgrade to v4.x.
-
-For more information, see [Java buildpack 4.0](https://www.cloudfoundry.org/just-released-java-buildpack-4-0/).


### PR DESCRIPTION
Java Buildpack v3 is long out of support, removing outdated references to it from the memory constraints section