### PR TITLE
fix: adjust CNB URL to Docker Hub

### DIFF
--- a/cnb/index.html.md.erb
+++ b/cnb/index.html.md.erb
@@ -23,7 +23,7 @@ applications:
 - name: cf-nodejs
   lifecycle: cnb
   buildpacks:
-  - docker://gcr.io/paketo-buildpacks/nodejs
+  - docker://docker.io/paketobuildpacks/nodejs
   memory: 512M
   instances: 1
   random-route: true


### PR DESCRIPTION
Support for GCR has been discontinued and buildpacks should now be pulled from Docker Hub.

See: https://blog.paketo.io/posts/paketo-gcr-registry-sunset/