### PR TITLE
Remove deprecated cf push -n flag from getting-started guides

### DIFF
--- a/java/getting-started-deploying-apps/gsg-grails.html.md.erb
+++ b/java/getting-started-deploying-apps/gsg-grails.html.md.erb
@@ -237,21 +237,16 @@ Once your app deploys, browse to your app URL. Search for the `urls` field in th
 <div class="note important">
   <ol>
     <li>Change to the <code>app</code>directory, and run <code>./grailsw war</code> to build the app.</li>
-    <li>Run <code>cf push pong_matcher_grails -n HOST-NAME</code> to push the app.</li>
+    <li>Run <code>cf push pong_matcher_grails</code> to push the app.</li>
   </ol>
-    <br />
-    Example: <code>cf push pong_matcher_grails -n my-grails-app</code>
-    <br /><br />
-    <b>This example works for cf CLI v6. The <code>-n</code> flag is not supported for cf CLI v7/v8. Hostname must be set using the <code>routes</code> property in the manifest.</b>
 </div>
 
 You do not have to include the <code>-p</code> flag when you deploy the sample app. The sample app manifest declares the path to the archive that <code>cf push</code> uses to upload the app files.
 
 The following example shows the terminal output of deploying the <code>pong_matcher_grails</code> app. <code>cf push</code> uses the instructions in the manifest file to create the app, create and bind the route, and upload the app. It then binds the app to the <code>mysql</code> service and follows the instructions in the manifest to start two instances of the app, allocating 1 GB of memory between the instances. After the instances start, the output displays their health and status.
-This example works for cf CLI v6. The `-n` flag is not supported for cf CLI v7/v8. Hostname must be set using the `routes` property in the manifest.
 
 <pre class="terminal">
-$ cf push pong_matcher_grails -n my-grails-app
+$ cf push pong_matcher_grails
 Using manifest file /Users/example/workspace/pong_matcher_grails/app/manifest.yml
 
 Creating app pong_matcher_grails in org Cloud-Apps / space development as clouduser@example.com...

--- a/java/getting-started-deploying-apps/gsg-ratpack.html.md.erb
+++ b/java/getting-started-deploying-apps/gsg-ratpack.html.md.erb
@@ -215,7 +215,6 @@ For example, `cf push my-app` creates the URL `my-app.<%= vars.app_domain %>`.
 
 The URL for your app must be unique from other apps that Cloud Foundry hosts or the push fails. Use the following options to help create a unique URL:
 
-* `-n` to assign a different HOST name for the app
 * `--random-route` to create a URL that includes the app name and random words
 * `cf help push` to view other options for this command
 
@@ -225,18 +224,14 @@ Once your app deploys, browse to your app URL. Search for the `urls` field in th
 
 **Sample app step**
 1. Change to the `app` directory, and run `./gradlew distZip` to build the app.
-1. Run `cf push pong_matcher_groovy -n HOST-NAME` to push the app.
-Example: `cf push pong_matcher_groovy -n groovy-ratpack-app`
-
-This example is valid for cf CLI v6. In cf CLI v7 and onwards, the <code>-n</code> flag is not supported. The host name must be specified in the manifest, using the <code>routes</code> attribute.
+1. Run `cf push pong_matcher_groovy` to push the app.
 
 You do not have to include the <code>-p</code> flag when you deploy the sample app. The sample app manifest declares the path to the archive that <code>cf push</code> uses to upload the app files.
 
 The following example shows the terminal output of deploying the <code>pong_matcher_groovy</code> app. <code>cf push</code> uses the instructions in the manifest file to create the app, create and bind the route, and upload the app. It then binds the app to the <code>baby-redis</code> service and follows the instructions in the manifest to start one instance of the app with 512 MB. After the app starts, the output displays the health and status of the app.
-Note, this example is valid for cf CLI v6. In cf CLI v7 and onwards, the `-n` flag is not supported. The host name must be specified in the manifest, using the `routes` attribute.
 
 <pre class="terminal">
-$ cf push pong_matcher_groovy -n groovy-ratpack-app
+$ cf push pong_matcher_groovy
 Using manifest file /Users/example/workspace/pong_matcher_groovy/app/manifest.yml
 
 Creating app pong_matcher_groovy in org Cloud-Apps / space development as clouduser@example.com...

--- a/java/getting-started-deploying-apps/gsg-spring.html.md.erb
+++ b/java/getting-started-deploying-apps/gsg-spring.html.md.erb
@@ -198,17 +198,14 @@ Once your app deploys, go to your app URL. Search for the `urls` field in the `A
 
 1. Run `brew install maven`.
 1. Change to the `app` directory, and run `mvn package` to build the app.
-1. Run `cf push pong_matcher_spring -n HOSTNAME` to push the app.
-Example: `cf push pong_matcher_spring -n my-spring-app`.
+1. Run `cf push pong_matcher_spring` to push the app.
 
-This example works for cf CLI v6. The <code>-n</code> flag is not supported for cf CLI v7/v8. Hostname must be set using the <code>routes</code> property in the manifest.
 You do not have to include the <code>-p</code> flag when you deploy the sample app. The sample app manifest declares the path to the archive that <code>cf push</code> uses to upload the app files.
 
-The following example shows the terminal output of deploying the <code>pong_matcher_spring</code> app. <code>cf push</code> uses the instructions in the manifest file to create the app, create and bind the route, and upload the app. It then binds the app to the <code>mysql</code> service and starts one instance of the app with 1 GB of memory. After the app starts, the output displays
-the health and status of the app. This example works for cf CLI v6. The <code>-n</code> flag is not supported for cf CLI v7/v8. Hostname must be set using the <code>routes</code> property in the manifest.
+The following example shows the terminal output of deploying the <code>pong_matcher_spring</code> app. <code>cf push</code> uses the instructions in the manifest file to create the app, create and bind the route, and upload the app. It then binds the app to the <code>mysql</code> service and starts one instance of the app with 1 GB of memory. After the app starts, the output displays the health and status of the app.
 
 <pre class="terminal">
-$ cf push pong_matcher_spring -n spring1119
+$ cf push pong_matcher_spring
 Using manifest file /Users/example/workspace/pong_matcher_spring/manifest.yml
 
 Creating app pong_matcher_spring in org Cloud-Apps / space development as a.user@example.com...

--- a/ruby/gsg-ruby.html.md.erb
+++ b/ruby/gsg-ruby.html.md.erb
@@ -169,7 +169,6 @@ The URL for your app must be unique from other apps that Cloud Foundry
 hosts or the push fails.
 Use the following options to help create a unique URL:
 
-* `-n` to assign a different HOST name for the app.
 * `--random-route` to create a URL that includes the app name and random words.
 * `cf help push` to view other options for this command.
 
@@ -180,15 +179,11 @@ Once your app deploys, browse to your app URL.
 Search for the `urls` field in the `App started` block in the output of the `cf push` command.
 Use the URL to access your app online.
 
-Run <code>cf push pong_matcher_ruby -n HOST_NAME</code>.<br /><br />Example: <code>cf push
-pong_matcher_ruby -n pongmatch-ex12</code> <br /><br />The following example shows the terminal output of
-deploying the <code>pong_matcher_ruby</code> app. The n<code>cf push</code> command uses the instructions in
+Run <code>cf push pong_matcher_ruby</code>.<br /><br />The following example shows the terminal output of
+deploying the <code>pong_matcher_ruby</code> app. The <code>cf push</code> command uses the instructions in
 the manifest file to create the app, create and bind the route, and upload the app. It then binds the app to
 the <code>redis</code> service and follows the instructions in the manifest to start one instance of the
 app with 256M. After the app starts, the output displays the health and status of the app.
-
-These examples work for cf CLI v6. The <code>-n</code> flag is not supported for cf CLI v7/v8. Hostname must
-be set using the <code>routes</code> property in the manifest.
 
 The <code>pong_matcher_ruby</code> app does not include a web interface. To interact with
 the <code>pong_matcher_ruby</code> app, see the interaction instructions on GitHub: <a href="https://github.com/cloudfoundry-samples/pong_matcher_ruby">https://github.com/cloudfoundry-samples/pong_matcher_ruby</a>.


### PR DESCRIPTION
## Summary

- Removes `cf push APP_NAME -n HOSTNAME` from 4 getting-started guide files (gsg-ruby, gsg-spring, gsg-grails, gsg-ratpack)
- The `-n`/`--hostname` flag was removed from `cf push` in cf CLI v7; cf CLI v8 is the current version
- Also removes the inline deprecation notes that acknowledged the issue but left the incorrect commands in place
- Removes the `-n` bullet from options lists in gsg-ruby and gsg-ratpack

Related: cloudfoundry/docs-dev-guide#511

## Test plan

- [ ] Confirm no `cf push ... -n` commands remain in the 4 changed files
- [ ] Confirm prose instructions no longer mention the `-n` hostname flag

🤖 Generated with [Claude Code](https://claude.com/claude-code)